### PR TITLE
Fixes packaging to use updated log-cache pkg

### DIFF
--- a/packages/log-cache/packaging
+++ b/packages/log-cache/packaging
@@ -7,7 +7,7 @@ export GOROOT=$(readlink -nf /var/vcap/packages/golang1.9.4)
 export GOPATH=$BOSH_INSTALL_TARGET
 export PATH=$GOROOT/bin:$PATH
 
-go build -o ${BOSH_INSTALL_TARGET}/log-cache code.cloudfoundry.org/log-cache/cmd/logcache
+go build -o ${BOSH_INSTALL_TARGET}/log-cache code.cloudfoundry.org/log-cache/cmd/log-cache
 
 # clean up source artifacts
 rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -30,7 +30,7 @@ function sync_package() {
   )
 }
 
-sync_package log-cache                   -app  code.cloudfoundry.org/log-cache/cmd/logcache &
+sync_package log-cache                   -app  code.cloudfoundry.org/log-cache/cmd/log-cache &
 sync_package log-cache-gateway           -app  code.cloudfoundry.org/log-cache/cmd/gateway &
 sync_package log-cache-nozzle            -app  code.cloudfoundry.org/log-cache/cmd/nozzle &
 sync_package log-cache-expvar-forwarder  -app  code.cloudfoundry.org/log-cache/cmd/expvar-forwarder &


### PR DESCRIPTION
Closes cloudfoundry/log-cache#39

References https://github.com/cloudfoundry/log-cache/pull/44