### PR TITLE
Share Log Cache Group Reader Link

### DIFF
--- a/manifests/log-cache.yml
+++ b/manifests/log-cache.yml
@@ -63,6 +63,8 @@ instance_groups:
     release: log-cache
     properties:
       port: 8084
+    provides:
+      log-cache-group-reader: {shared: true}
   - name: log-cache-nozzle
     release: log-cache
     consumes:


### PR DESCRIPTION
The Group Reader is a public-facing API similar to log cache. We should expose a link to it so it can be consumed by other bosh-deployed products.