### PR TITLE
Add ability to override bosh-links for addresses

### DIFF
--- a/jobs/log-cache-cf-auth-proxy/spec
+++ b/jobs/log-cache-cf-auth-proxy/spec
@@ -77,3 +77,6 @@ properties:
   logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
+
+  cc.address:
+    description: "Override as alternative to using CC link"

--- a/jobs/log-cache-cf-auth-proxy/spec
+++ b/jobs/log-cache-cf-auth-proxy/spec
@@ -78,5 +78,5 @@ properties:
     description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
 
-  cc.address:
+  cc.override_address:
     description: "Override as alternative to using CC link"

--- a/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
+++ b/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
@@ -4,6 +4,14 @@
 
   gw = link('log-cache-gateway')
   cc = link('cloud_controller')
+  cc_address = ""
+  if_p("cc.address") { |addr|
+    cc_address = addr
+  }.else_if_link('cloud_controller') { |cc|
+    cc = link('cloud_controller')
+    cc_address = cc.addr
+  }
+
 %>
 ---
 processes:
@@ -22,7 +30,7 @@ processes:
     TOKEN_PRUNING_INTERVAL:    "<%= p('token_pruning_interval') %>"
     CACHE_EXPIRATION_INTERVAL: "<%= p('cache_expiration_interval') %>"
 
-    CAPI_ADDR:          "<%= "https://#{cc.address}:9024" %>"
+    CAPI_ADDR:          "<%= "https://#{cc_address}:9024" %>"
     CAPI_CA_PATH:       "<%= "#{certDir}/cc_ca.crt" %>"
     CAPI_COMMON_NAME:   "<%= p('cc.common_name') %>"
 

--- a/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
+++ b/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
@@ -4,11 +4,11 @@
 
   gw = link('log-cache-gateway')
   cc_address = ""
-  if_p("cc.address") { |addr|
+  if_p("cc.override_address") { |addr|
     cc_address = addr
   }.else_if_link('cloud_controller') { |cc|
     cc = link('cloud_controller')
-    cc_address = cc.addr
+    cc_address = cc.address
   }
 
 %>

--- a/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
+++ b/jobs/log-cache-cf-auth-proxy/templates/bpm.yml.erb
@@ -3,7 +3,6 @@
   certDir = "#{jobDir}/config/certs"
 
   gw = link('log-cache-gateway')
-  cc = link('cloud_controller')
   cc_address = ""
   if_p("cc.address") { |addr|
     cc_address = addr

--- a/jobs/log-cache-nozzle/spec
+++ b/jobs/log-cache-nozzle/spec
@@ -48,3 +48,5 @@ properties:
   logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
+  rlp.override_address:
+    description: "Override of bosh links for reverse-log-proxy url"

--- a/jobs/log-cache-nozzle/templates/bpm.yml.erb
+++ b/jobs/log-cache-nozzle/templates/bpm.yml.erb
@@ -4,6 +4,11 @@
 
   lc = link("log-cache")
   rlp = link('reverse_log_proxy')
+  rlp_address = rlp.address
+  if_p("rlp.override_address") { |addr|
+    rlp_address = addr
+  }
+
 %>
 ---
 processes:
@@ -13,7 +18,7 @@ processes:
     HEALTH_PORT: "<%= p('health_port') %>"
 
     # Logs Provider
-    LOGS_PROVIDER_ADDR: "<%= "#{rlp.address}:#{rlp.p('reverse_log_proxy.egress.port')}" %>"
+    LOGS_PROVIDER_ADDR: "<%= "#{rlp_address}:#{rlp.p('reverse_log_proxy.egress.port')}" %>"
     LOGS_PROVIDER_CA_FILE_PATH:   "<%= "#{certDir}/logs_provider_ca.crt" %>"
     LOGS_PROVIDER_CERT_FILE_PATH: "<%= "#{certDir}/logs_provider.crt" %>"
     LOGS_PROVIDER_KEY_FILE_PATH:  "<%= "#{certDir}/logs_provider.key" %>"

--- a/jobs/log-cache/spec
+++ b/jobs/log-cache/spec
@@ -28,6 +28,13 @@ consumes:
   type: log-cache
 
 properties:
+
+  append_node_addresses:
+    description: "Array of log-cache instances to add to bosh links"
+
+  prepend_node_addresses:
+    description: "Array of log-cache instances to add to bosh links"
+
   port:
     description: "The port for the log-cache to listen on"
     default: 8080

--- a/jobs/log-cache/templates/bpm.yml.erb
+++ b/jobs/log-cache/templates/bpm.yml.erb
@@ -5,10 +5,18 @@
   lc = link("log-cache")
 
   sorted_cache_instances = lc.instances.sort_by {|i| i.address}
-  cache_addrs = sorted_cache_instances.map {|i| "#{i.address}:#{p('port')}"}
   index = sorted_cache_instances.index(
       sorted_cache_instances.find {|i| i.id == spec.id}
   )
+  cache_addrs = []
+  if_p("prepend_node_addresses") do |paddrs|
+    cache_addrs += paddrs.map{|addr| "#{addr}:#{p('port')}"}
+    index += cache_addrs.length()
+  end
+  cache_addrs += sorted_cache_instances.map {|i| "#{i.address}:#{p('port')}"}
+  if_p("append_node_addresses") do |paddrs|
+    cache_addrs += paddrs.map{|addr| "#{addr}:#{p('port')}"}
+  end
 %>
 ---
 processes:


### PR DESCRIPTION
For some "hybrid" deployment work where we have both BOSH and KUBECF we need the ability to override certain properties.

This is a common pattern across many different releases and by default will not be used.  but it can allow us to override certain properties if required.