### PR TITLE
Bump gosigar v1.1.0 → v1.2.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/benjamintf1/unmarshalledmatchers v0.0.0-20190408201839-bb1c1f34eaea // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cespare/xxhash v1.1.0
-	github.com/cloudfoundry/gosigar v1.1.0
+	github.com/cloudfoundry/gosigar v1.2.0
 	github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a
 	github.com/emirpasic/gods v1.12.0
 	github.com/go-logfmt/logfmt v0.5.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -82,8 +82,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry/dropsonde v1.0.0/go.mod h1:6zwvrWK5TpxBVYi1cdkE5WDsIO8E0n7qAJg3wR9B67c=
-github.com/cloudfoundry/gosigar v1.1.0 h1:V/dVCzhKOdIU3WRB5inQU20s4yIgL9Dxx/Mhi0SF8eM=
-github.com/cloudfoundry/gosigar v1.1.0/go.mod h1:3qLfc2GlfmwOx2+ZDaRGH3Y9fwQ0sQeaAleo2GV5pH0=
+github.com/cloudfoundry/gosigar v1.2.0 h1:WhQ4aCTT5XqEdoqsPbVbskf1fprablU46Ts14Q9fSro=
+github.com/cloudfoundry/gosigar v1.2.0/go.mod h1:3qLfc2GlfmwOx2+ZDaRGH3Y9fwQ0sQeaAleo2GV5pH0=
 github.com/cloudfoundry/gosteno v0.0.0-20150423193413-0c8581caea35/go.mod h1:3YBPUR85RIrvaUTdA1dL38YSp6s3OHu1xrWLkGt2Mog=
 github.com/cloudfoundry/loggregatorlib v0.0.0-20170823162133-36eddf15ef12/go.mod h1:ucj7+svyACshmxV3Zze2NAcEcdbBf9scZYR+QKCX9/w=
 github.com/cloudfoundry/sonde-go v0.0.0-20171206171820-b33733203bb4/go.mod h1:GS0pCHd7onIsewbw8Ue9qa9pZPv2V88cUZDttK6KzgI=

--- a/src/vendor/github.com/cloudfoundry/gosigar/Vagrantfile
+++ b/src/vendor/github.com/cloudfoundry/gosigar/Vagrantfile
@@ -10,9 +10,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   set -e
 
 if [ ! -d "/usr/local/go" ]; then
-	cd /tmp && wget https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz
+	cd /tmp && wget https://storage.googleapis.com/golang/go1.13.15.linux-amd64.tar.gz
 	cd /usr/local
-	tar xvzf /tmp/go1.9.1.linux-amd64.tar.gz
+	tar xvzf /tmp/go1.13.15.linux-amd64.tar.gz
 	echo 'export GOPATH=/home/vagrant/go; export PATH=/usr/local/go/bin:$PATH:$GOPATH/bin' >> /home/vagrant/.bashrc
 fi
 export GOPATH=/home/vagrant/go

--- a/src/vendor/github.com/cloudfoundry/gosigar/sigar_linux.go
+++ b/src/vendor/github.com/cloudfoundry/gosigar/sigar_linux.go
@@ -3,6 +3,7 @@ package sigar
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,11 +20,47 @@ var system struct {
 }
 
 var Procd string
+var Sysd1 string
+var Sysd2 string
+
+// Files in system directories used here
+//   - Procd
+//       - /stat
+//       - /meminfo
+//       - /self/cgroup | 'grep :memory:' | split ':' | last => cgroup
+//       - /self/cgroup | 'grep ::'       | split ':' | last => cgroup/fallback
+//       - /self/mounts
+//   - Sysd1 (cgroup v1)
+//       - memory/<cgroup>/memory.limit_in_bytes
+//       - memory/<cgroup>/memory.stat
+//   - Sysd2 (cgroup v2)
+//	 - <cgroup>/memory.high
+//	 - <cgroup>/memory.current
+//	 - <cgroup>/memory.swap.current
+//
+// While Procd is fixed `/proc` the `Sysd*` directories are
+// dynamic. I.e. while there are semi-standard mount points for the
+// cgroup controllers, this is just convention. They can be mounted
+// anywhere. The file `/proc/self/mounts` contains the information we
+// need.
 
 func init() {
 	system.ticks = 100 // C.sysconf(C._SC_CLK_TCK)
 
 	Procd = "/proc"
+	Sysd1 = ""
+	Sysd2 = ""
+
+	determineControllerMounts(&Sysd1, &Sysd2)
+
+	// Fallbacks for cgroup controller mount points if nothing was
+	// found in /proc/self/mounts
+	if Sysd1 == "" {
+		Sysd1 = "/sys/fs/cgroup/memory"
+	}
+	if Sysd2 == "" {
+		Sysd2 = "/sys/fs/cgroup/unified"
+	}
 
 	// grab system boot time
 	readFile(Procd+"/stat", func(line string) bool {
@@ -85,6 +122,70 @@ func (self *Mem) Get() error {
 
 	self.Used = self.Total - self.Free
 	self.ActualUsed = self.Total - self.ActualFree
+
+	// Instead of detecting if this code is run within a container
+	// or not (*), we simply attempt to retrieve the cgroup
+	// information about memory limits and usage and if present
+	// incorporate them into the results.
+	//
+	// 0. If we are unable to determine the Cgroup for the process
+	//    we ignore it and stay with the host data.
+	//
+	// 1. If the cgroup limit is not available we ignore it and
+	//    stay with the host data.
+	//
+	// 2. Note that we are taking the smaller of host total and
+	//    cgroup limit, as the safer value for the total. The
+	//    reason here is that there are Linux systems which report
+	//    something like 8 EiB (Exa!) (**) as the cgroup limit, on
+	//    systems which have only 64 GiB (Giga) of physical RAM.
+	//
+	// (*) There does not seem to be a truly reliable and portable
+	//     means of detecting execution inside a container vs
+	//     outside. Between all the platforms (macos, linux,
+	//     windows), and container runtimes (docker, lxc, oci, ...).
+	//
+	// (**) The exact value actually is 2^63 - 4096, i.e
+	//	8 EiB - 4 KiB.  This is, as far as is known, the
+	//	maximum limit of the Linux virtual memory system.
+
+	var cgroup string
+	if err := determineSelfCgroup(&cgroup); err != nil {
+		// Unable to determine process' Cgroup
+		return nil
+	}
+
+	cgroupLimit, err := determineMemoryLimit(cgroup)
+	// (x) If the limit is not available or bogus we keep the host data as limit.
+
+	if err == nil && cgroupLimit < self.Total {
+		// See (2) above why only a cgroup limit less than the
+		// host total is accepted as the new total available
+		// memory in the cgroup.
+		self.Total = cgroupLimit
+	}
+
+	rss, err := determineMemoryUsage(cgroup)
+
+	if err != nil {
+		return nil
+	}
+
+	swap, err := determineSwapUsage(cgroup)
+	if err != nil {
+		// Swap information is optional. I.e. the kernel may
+		// have swap accounting disabled.  Because of this any
+		// kind of trouble determining the swap usage is
+		// mapped to `no swap used`. This allows us to limp
+		// on with some inaccuracies, instead of aborting.
+		swap = 0
+	}
+
+	self.Used = rss + swap
+	self.Free = self.Total - self.Used
+
+	self.ActualUsed = self.Used
+	self.ActualFree = self.Free
 
 	return nil
 }
@@ -316,6 +417,119 @@ func (self *ProcExe) Get(pid int) error {
 	return nil
 }
 
+func determineSwapUsage(cgroup string) (uint64, error) {
+	// Check v2 over v1
+	usageAsString, err := ioutil.ReadFile(Sysd2 + cgroup + "/memory.swap.current")
+	if err == nil {
+		return strtoull(strings.Split(string(usageAsString), "\n")[0])
+	}
+
+	var swap uint64
+	table := map[string]*uint64{
+		"swap": &swap,
+	}
+
+	err, found := parseCgroupMeminfo(Sysd1+cgroup, table)
+	if err == nil {
+		if !found {
+			// If no data was found, simply claim `zero swap used`.
+			return 0, errors.New("no data found")
+		}
+		return swap, nil
+	}
+
+	return 0, err
+}
+
+func determineMemoryUsage(cgroup string) (uint64, error) {
+	// Check v2 over v1
+	usageAsString, err := ioutil.ReadFile(Sysd2 + cgroup + "/memory.current")
+	if err == nil {
+		return strtoull(strings.Split(string(usageAsString), "\n")[0])
+	}
+
+	var rss uint64
+	table := map[string]*uint64{
+		"total_rss": &rss,
+	}
+
+	err, found := parseCgroupMeminfo(Sysd1+cgroup, table)
+	if err == nil {
+		if !found {
+			return 0, errors.New("no data found")
+		}
+		return rss, nil
+	}
+
+	return 0, err
+}
+
+func determineMemoryLimit(cgroup string) (uint64, error) {
+	// Check v2 over v1
+	limitAsString, err := ioutil.ReadFile(Sysd2 + cgroup + "/memory.high")
+	if err == nil {
+		val := strings.Split(string(limitAsString), "\n")[0]
+		if val == "max" {
+			return 0, errors.New("no limit")
+			// See (x) in the caller where this keeps the host's self.Total.
+		}
+		return strtoull(val)
+	}
+
+	limitAsString, err = ioutil.ReadFile(Sysd1 + cgroup + "/memory.limit_in_bytes")
+	if err == nil {
+		return strtoull(strings.Split(string(limitAsString), "\n")[0])
+	}
+
+	return 0, err
+}
+
+func determineSelfCgroup(cgroup *string) error {
+	// - /proc/self/cgroup
+	//   Expected line syntax - id:tag:path
+	//   Three fields required in each line.
+
+	// Look for a cgroup v1 memory controller first
+	err := readFile(Procd+"/self/cgroup", func(line string) bool {
+		fields := strings.Split(line, ":")
+		// Match: `*:memory:/path`
+		if len(fields) < 3 {
+			return true
+		}
+		if fields[1] == "memory" {
+			*cgroup = strings.Trim(fields[len(fields)-1], " ")
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	if *cgroup != "" {
+		return nil
+	}
+
+	// Fall back to a cgroup v2 memory controller
+	err = readFile(Procd+"/self/cgroup", func(line string) bool {
+		fields := strings.Split(line, ":")
+		// Match: `0::/path`
+		if len(fields) < 3 {
+			return true
+		}
+		if (fields[0] == "0") && (fields[1] == "") {
+			*cgroup = strings.Trim(fields[len(fields)-1], " ")
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	if *cgroup != "" {
+		return nil
+	}
+
+	return errors.New("unable to determine control group")
+}
+
 func parseMeminfo(table map[string]*uint64) error {
 	return readFile(Procd+"/meminfo", func(line string) bool {
 		fields := strings.Split(line, ":")
@@ -330,6 +544,27 @@ func parseMeminfo(table map[string]*uint64) error {
 
 		return true
 	})
+}
+
+func parseCgroupMeminfo(cgroupDir string, table map[string]*uint64) (error, bool) {
+	var found bool
+	err := readFile(cgroupDir+"/memory.stat", func(line string) bool {
+		fields := strings.Split(line, " ")
+		if ptr := table[fields[0]]; ptr != nil {
+			num := strings.TrimLeft(fields[1], " ")
+			val, err := strtoull(strings.Fields(num)[0])
+			if err == nil {
+				*ptr = val
+				found = true
+			}
+		}
+
+		return true
+	})
+	if err != nil {
+		return err, false
+	}
+	return nil, found
 }
 
 func parseCpuStat(self *Cpu, line string) error {
@@ -389,4 +624,57 @@ func readProcFile(pid int, name string) ([]byte, error) {
 	}
 
 	return contents, err
+}
+
+func determineControllerMounts(sysd1, sysd2 *string) {
+	// grab cgroup controller mount points
+	readFile(Procd+"/self/mounts", func(line string) bool {
+
+		// Entries have the form `device path type options`.
+		// The elements are separated by single spaces.
+		//
+		// v2: `path` element of entry fulfilling `type == "cgroup2"`.
+		// v1: `path` element of entry fulfilling `type == "cgroup" && options ~ "memory"`
+		//
+		// NOTE: The `device` column can be anything. It
+		// cannot be used to pare down the set of entries
+		// going into the full check.
+
+		fields := strings.Split(line, " ")
+		if len(fields) < 4 {
+			return true
+		}
+
+		mpath := fields[1]
+		mtype := fields[2]
+		moptions := fields[3]
+
+		if mtype == "cgroup2" {
+			if *sysd2 != "" {
+				panic("Multiple cgroup v2 mount points")
+			}
+			*sysd2 = mpath
+			return true
+		}
+		if mtype == "cgroup" {
+			options := strings.Split(moptions, ",")
+			if stringSliceContains(options, "memory") {
+				if *sysd1 != "" {
+					panic("Multiple cgroup v1 mount points")
+				}
+				*sysd1 = mpath
+				return true
+			}
+		}
+		return true
+	})
+}
+
+func stringSliceContains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
 }

--- a/src/vendor/modules.txt
+++ b/src/vendor/modules.txt
@@ -33,7 +33,7 @@ github.com/blang/semver
 github.com/cespare/xxhash
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/cloudfoundry/gosigar v1.1.0
+# github.com/cloudfoundry/gosigar v1.2.0
 github.com/cloudfoundry/gosigar
 github.com/cloudfoundry/gosigar/sys/windows
 # github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a


### PR DESCRIPTION
The gosigar bump includes https://github.com/cloudfoundry/gosigar/pull/50 to correctly calculate the available memory inside a container, which in turn should fix https://github.com/cloudfoundry/log-cache-release/issues/29.

Fixes #43 