### PR TITLE
Update the max recv msg size for the log-cache gateway

### DIFF
--- a/src/cmd/gateway/main.go
+++ b/src/cmd/gateway/main.go
@@ -62,11 +62,13 @@ func main() {
 	if cfg.TLS.HasAnyCredential() {
 		gatewayOptions = append(gatewayOptions, WithGatewayLogCacheDialOpts(
 			grpc.WithTransportCredentials(cfg.TLS.Credentials("log-cache")),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*8)),
 		),
 		)
 	} else {
 		gatewayOptions = append(gatewayOptions, WithGatewayLogCacheDialOpts(
 			grpc.WithInsecure(),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*8)),
 		),
 		)
 


### PR DESCRIPTION
- on large environments the meta call can be quite big, updating this by default to allow a full meta call to return from log-cache
- thanks Andrew Edgar for help working on and testing this update and fix!