### PR TITLE
Make log-cache truncation interval configurable

### DIFF
--- a/jobs/log-cache/spec
+++ b/jobs/log-cache/spec
@@ -47,6 +47,10 @@ properties:
     description: "The maximum number of items stored in LogCache per source."
     default: 100000
 
+  truncation_interval:
+    description: "The amount of time between log-cache checking if it needs to prune"
+    default: "500ms"
+
   promql.query_timeout:
     description: "The maximum allowed runtime for a single PromQL query. Smaller timeouts are recommended."
     default: "10s"

--- a/jobs/log-cache/templates/bpm.yml.erb
+++ b/jobs/log-cache/templates/bpm.yml.erb
@@ -27,6 +27,7 @@ processes:
     MEMORY_LIMIT_PERCENT: "<%= p('memory_limit_percent') %>"
     MAX_PER_SOURCE: "<%= p('max_per_source') %>"
     QUERY_TIMEOUT: "<%= p('promql.query_timeout') %>"
+    TRUNCATION_INTERVAL: "<%= p('truncation_interval') %>"
 
     CA_PATH:   "<%= "#{certDir}/ca.crt" %>"
     CERT_PATH: "<%= "#{certDir}/log_cache.crt" %>"

--- a/src/cmd/log-cache/config.go
+++ b/src/cmd/log-cache/config.go
@@ -31,6 +31,12 @@ type Config struct {
 	// minute. Default is 100000.
 	MaxPerSource int `env:"MAX_PER_SOURCE, report"`
 
+	// TruncationInterval sets the delay between invocations of the
+	// truncation loop. This is where log-cache checks if memory utilization
+	// has gone above MemoryLimitPercent and evicts envelopes if it has.
+	// Default is 500ms.
+	TruncationInterval time.Duration `env:"TRUNCATION_INTERVAL, report"`
+
 	// NodeIndex determines what data the node stores. It splits up the range
 	// of 0 - 18446744073709551615 evenly. If data falls out of range of the
 	// given node, it will be routed to theh correct one.
@@ -55,6 +61,7 @@ func LoadConfig() (*Config, error) {
 		QueryTimeout:       10 * time.Second,
 		MemoryLimitPercent: 50,
 		MaxPerSource:       100000,
+		TruncationInterval: 500 * time.Millisecond,
 		MetricsServer: config.MetricsServer{
 			Port: 6060,
 		},

--- a/src/cmd/log-cache/main.go
+++ b/src/cmd/log-cache/main.go
@@ -75,6 +75,7 @@ func main() {
 		WithMemoryLimit(cfg.MemoryLimit),
 		WithMaxPerSource(cfg.MaxPerSource),
 		WithQueryTimeout(cfg.QueryTimeout),
+		WithTruncationInterval(cfg.TruncationInterval),
 	}
 	var transport grpc.DialOption
 	if cfg.TLS.HasAnyCredential() {

--- a/src/internal/cache/store/store.go
+++ b/src/internal/cache/store/store.go
@@ -49,6 +49,8 @@ type Store struct {
 	mc      MemoryConsultant
 
 	truncationCompleted chan bool
+
+	truncationInterval time.Duration
 }
 
 type Metrics struct {
@@ -61,7 +63,7 @@ type Metrics struct {
 	memoryUtilization  metrics.Gauge
 }
 
-func NewStore(maxPerSource int, mc MemoryConsultant, m MetricsRegistry) *Store {
+func NewStore(maxPerSource int, truncationInterval time.Duration, mc MemoryConsultant, m MetricsRegistry) *Store {
 	store := &Store{
 		maxPerSource:      maxPerSource,
 		maxTimestampFudge: 4000,
@@ -71,11 +73,13 @@ func NewStore(maxPerSource int, mc MemoryConsultant, m MetricsRegistry) *Store {
 
 		mc:                  mc,
 		truncationCompleted: make(chan bool),
+
+		truncationInterval: truncationInterval,
 	}
 
 	store.mc.SetMemoryReporter(store.metrics.memoryUtilization)
 
-	go store.truncationLoop(500 * time.Millisecond)
+	go store.truncationLoop(store.truncationInterval)
 
 	return store
 }

--- a/src/internal/cache/store/store_benchmark_test.go
+++ b/src/internal/cache/store/store_benchmark_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	MaxPerSource = 1000000
+	MaxPerSource       = 1000000
+	TruncationInterval = 500 * time.Millisecond
 )
 
 var (
@@ -28,7 +29,7 @@ var (
 )
 
 func BenchmarkStoreWrite(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -38,7 +39,7 @@ func BenchmarkStoreWrite(b *testing.B) {
 }
 
 func BenchmarkStoreTruncationOnWrite(b *testing.B) {
-	s := store.NewStore(100, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(100, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -48,7 +49,7 @@ func BenchmarkStoreTruncationOnWrite(b *testing.B) {
 }
 
 func BenchmarkStoreWriteParallel(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 
@@ -61,7 +62,7 @@ func BenchmarkStoreWriteParallel(b *testing.B) {
 }
 
 func BenchmarkStoreGetTime5MinRange(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < MaxPerSource/10; i++ {
 		e := gen()
@@ -77,7 +78,7 @@ func BenchmarkStoreGetTime5MinRange(b *testing.B) {
 }
 
 func BenchmarkStoreGetLogType(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < MaxPerSource/10; i++ {
 		e := gen()
@@ -93,7 +94,7 @@ func BenchmarkStoreGetLogType(b *testing.B) {
 }
 
 func BenchmarkMeta(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < b.N; i++ {
 		e := gen()
@@ -107,7 +108,7 @@ func BenchmarkMeta(b *testing.B) {
 }
 
 func BenchmarkMetaWhileWriting(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	ready := make(chan struct{}, 1)
 	go func() {
@@ -126,7 +127,7 @@ func BenchmarkMetaWhileWriting(b *testing.B) {
 }
 
 func BenchmarkMetaWhileReading(b *testing.B) {
-	s := store.NewStore(MaxPerSource, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < b.N; i++ {
 		e := gen()

--- a/src/internal/cache/store/store_load_test.go
+++ b/src/internal/cache/store/store_load_test.go
@@ -25,7 +25,7 @@ var _ = Describe("store under high concurrent load", func() {
 		sp.numberToPrune = 128
 		sm := testhelpers.NewMetricsRegistry()
 
-		loadStore := store.NewStore(2500, sp, sm)
+		loadStore := store.NewStore(2500, TruncationInterval, sp, sm)
 		start := time.Now()
 		var envelopesWritten uint64
 

--- a/src/internal/cache/store/store_test.go
+++ b/src/internal/cache/store/store_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Store", func() {
 	BeforeEach(func() {
 		sp = newSpyPruner()
 		sm = testhelpers.NewMetricsRegistry()
-		s = store.NewStore(5, sp, sm)
+		s = store.NewStore(5, TruncationInterval, sp, sm)
 	})
 
 	It("fetches data based on time and source ID", func() {
@@ -78,7 +78,7 @@ var _ = Describe("Store", func() {
 
 	Context("in ascending order", func() {
 		It("respects timestamp fudging when checking the time boundaries", func() {
-			s = store.NewStore(50, sp, sm)
+			s = store.NewStore(50, TruncationInterval, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -111,7 +111,7 @@ var _ = Describe("Store", func() {
 		})
 
 		It("intentionally exceeds the limit when it would otherwise break up a group of fudged timestamps", func() {
-			s = store.NewStore(50, sp, sm)
+			s = store.NewStore(50, TruncationInterval, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -132,7 +132,7 @@ var _ = Describe("Store", func() {
 
 	Context("in descending order", func() {
 		It("respects timestamp fudging when checking the time boundaries", func() {
-			s = store.NewStore(50, sp, sm)
+			s = store.NewStore(50, TruncationInterval, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -165,7 +165,7 @@ var _ = Describe("Store", func() {
 		})
 
 		It("intentionally exceeds the limit when it would otherwise break up a group of fudged timestamps", func() {
-			s = store.NewStore(50, sp, sm)
+			s = store.NewStore(50, TruncationInterval, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -313,7 +313,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("survives being over pruned", func() {
-		s = store.NewStore(10, sp, sm)
+		s = store.NewStore(10, TruncationInterval, sp, sm)
 		e1 := buildTypedEnvelope(0, "b", &loggregator_v2.Log{})
 		s.Put(e1, e1.GetSourceId())
 		sp.SetNumberToPrune(1000)
@@ -321,7 +321,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("truncates older envelopes when max size is reached", func() {
-		s = store.NewStore(10, sp, sm)
+		s = store.NewStore(10, TruncationInterval, sp, sm)
 		// e1 should be truncated and sourceID "b" should be forgotten.
 		e1 := buildTypedEnvelope(1, "b", &loggregator_v2.Log{})
 		// e2 should be truncated.
@@ -377,7 +377,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("truncates envelopes for a specific source-id if its max size is reached", func() {
-		s = store.NewStore(2, sp, sm)
+		s = store.NewStore(2, TruncationInterval, sp, sm)
 		// e1 should not be truncated
 		e1 := buildTypedEnvelope(1, "b", &loggregator_v2.Log{})
 		// e2 should be truncated
@@ -414,7 +414,7 @@ var _ = Describe("Store", func() {
 	// })
 
 	It("uses the given index", func() {
-		s = store.NewStore(2, sp, sm)
+		s = store.NewStore(2, TruncationInterval, sp, sm)
 		e := buildTypedEnvelope(0, "a", &loggregator_v2.Log{})
 		s.Put(e, "some-id")
 
@@ -426,7 +426,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("returns the indices in the store", func() {
-		s = store.NewStore(2, sp, sm)
+		s = store.NewStore(2, TruncationInterval, sp, sm)
 
 		// Will be pruned by pruner
 		s.Put(buildTypedEnvelope(1, "index-0", &loggregator_v2.Log{}), "index-0")
@@ -468,7 +468,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("survives the just added entry from being pruned", func() {
-		s = store.NewStore(2, sp, sm)
+		s = store.NewStore(2, TruncationInterval, sp, sm)
 
 		s.Put(buildTypedEnvelope(2, "index-0", &loggregator_v2.Log{}), "index-0")
 		s.Put(buildTypedEnvelope(3, "index-0", &loggregator_v2.Log{}), "index-0")
@@ -487,7 +487,7 @@ var _ = Describe("Store", func() {
 	It("demonstrates thread safety under heavy concurrent load", func() {
 		sp := newSpyPruner()
 		sp.SetNumberToPrune(10)
-		loadStore := store.NewStore(10000, sp, sm)
+		loadStore := store.NewStore(10000, TruncationInterval, sp, sm)
 		start := time.Now()
 
 		for i := 0; i < 10; i++ {


### PR DESCRIPTION
Allows users to configure the interval between truncation calls using a new `truncation_interval` property. The default of 500ms remains unchanged.

I originally implemented this as an attempted fix to https://github.com/cloudfoundry/log-cache-release/issues/50 but it doesn't appear to resolve the issue in my test environment. I decided to open this PR anyway since it seems like a useful thing to be configurable regardless.