### PR TITLE
Allow for running garbage collection as part of cache pruning process

### DIFF
--- a/jobs/log-cache/spec
+++ b/jobs/log-cache/spec
@@ -51,6 +51,10 @@ properties:
     description: "The amount of time between log-cache checking if it needs to prune"
     default: "500ms"
 
+  prunes_per_gc:
+    description: "Number of consecutive prunes to do before running garbage collection. Lowering the value increase CPU utilization"
+    default: 3
+
   promql.query_timeout:
     description: "The maximum allowed runtime for a single PromQL query. Smaller timeouts are recommended."
     default: "10s"

--- a/jobs/log-cache/spec
+++ b/jobs/log-cache/spec
@@ -49,7 +49,7 @@ properties:
 
   truncation_interval:
     description: "The amount of time between log-cache checking if it needs to prune"
-    default: "500ms"
+    default: "1s"
 
   prunes_per_gc:
     description: "Number of consecutive prunes to do before running garbage collection. Lowering the value increase CPU utilization"

--- a/jobs/log-cache/templates/bpm.yml.erb
+++ b/jobs/log-cache/templates/bpm.yml.erb
@@ -28,6 +28,7 @@ processes:
     MAX_PER_SOURCE: "<%= p('max_per_source') %>"
     QUERY_TIMEOUT: "<%= p('promql.query_timeout') %>"
     TRUNCATION_INTERVAL: "<%= p('truncation_interval') %>"
+    PRUNES_PER_GC: "<%= p('prunes_per_gc') %>"
 
     CA_PATH:   "<%= "#{certDir}/ca.crt" %>"
     CERT_PATH: "<%= "#{certDir}/log_cache.crt" %>"

--- a/src/cmd/log-cache/config.go
+++ b/src/cmd/log-cache/config.go
@@ -37,6 +37,14 @@ type Config struct {
 	// Default is 500ms.
 	TruncationInterval time.Duration `env:"TRUNCATION_INTERVAL, report"`
 
+	// PrunesPerGC sets the number of consecutive prunes needed to trigger
+	// a garbage collectionc call (GC). This setting is to guard against
+	// the cache pruning all envelopes before automatic GC updates the
+	// metric for memory used by the cache. Lowering the value increases CPU
+	// utilization.
+	// Default is 3
+	PrunesPerGC int64 `env:"PRUNES_PER_GC, report"`
+
 	// NodeIndex determines what data the node stores. It splits up the range
 	// of 0 - 18446744073709551615 evenly. If data falls out of range of the
 	// given node, it will be routed to theh correct one.
@@ -62,6 +70,7 @@ func LoadConfig() (*Config, error) {
 		MemoryLimitPercent: 50,
 		MaxPerSource:       100000,
 		TruncationInterval: 500 * time.Millisecond,
+		PrunesPerGC:        int64(3),
 		MetricsServer: config.MetricsServer{
 			Port: 6060,
 		},

--- a/src/cmd/log-cache/config.go
+++ b/src/cmd/log-cache/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	// NodeAddrs are all the LogCache addresses (including the current
 	// address). They are in order according to their NodeIndex.
 	//
-	// If NodeAddrs is emptpy or size 1, then data is not routed as it is
+	// If NodeAddrs is empty or size 1, then data is not routed as it is
 	// assumed that the current node is the only one.
 	NodeAddrs []string `env:"NODE_ADDRS, report"`
 

--- a/src/cmd/log-cache/config.go
+++ b/src/cmd/log-cache/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	// TruncationInterval sets the delay between invocations of the
 	// truncation loop. This is where log-cache checks if memory utilization
 	// has gone above MemoryLimitPercent and evicts envelopes if it has.
-	// Default is 500ms.
+	// Default is 1s.
 	TruncationInterval time.Duration `env:"TRUNCATION_INTERVAL, report"`
 
 	// PrunesPerGC sets the number of consecutive prunes needed to trigger
@@ -69,7 +69,7 @@ func LoadConfig() (*Config, error) {
 		QueryTimeout:       10 * time.Second,
 		MemoryLimitPercent: 50,
 		MaxPerSource:       100000,
-		TruncationInterval: 500 * time.Millisecond,
+		TruncationInterval: 1 * time.Second,
 		PrunesPerGC:        int64(3),
 		MetricsServer: config.MetricsServer{
 			Port: 6060,

--- a/src/cmd/log-cache/main.go
+++ b/src/cmd/log-cache/main.go
@@ -76,6 +76,7 @@ func main() {
 		WithMaxPerSource(cfg.MaxPerSource),
 		WithQueryTimeout(cfg.QueryTimeout),
 		WithTruncationInterval(cfg.TruncationInterval),
+		WithPrunesPerGC(cfg.PrunesPerGC),
 	}
 	var transport grpc.DialOption
 	if cfg.TLS.HasAnyCredential() {

--- a/src/internal/cache/log_cache.go
+++ b/src/internal/cache/log_cache.go
@@ -64,7 +64,7 @@ func New(m Metrics, logger *log.Logger, opts ...LogCacheOption) *LogCache {
 		maxPerSource:       100000,
 		memoryLimitPercent: 50,
 		queryTimeout:       10 * time.Second,
-		truncationInterval: 500 * time.Millisecond,
+		truncationInterval: 1 * time.Second,
 		prunesPerGC:        int64(3),
 
 		addr:     ":8080",
@@ -95,7 +95,7 @@ func WithMaxPerSource(size int) LogCacheOption {
 }
 
 // WithTruncationInterval returns a LogCacheOption that configures the
-// interval in ms on the store's truncation loop. Defaults to 500ms.
+// interval in ms on the store's truncation loop. Defaults to 1s.
 func WithTruncationInterval(interval time.Duration) LogCacheOption {
 	return func(c *LogCache) {
 		c.truncationInterval = interval

--- a/src/internal/cache/log_cache.go
+++ b/src/internal/cache/log_cache.go
@@ -41,6 +41,7 @@ type LogCache struct {
 	memoryLimit        uint64
 	queryTimeout       time.Duration
 	truncationInterval time.Duration
+	prunesPerGC        int64
 
 	// Cluster Properties
 	addr     string
@@ -64,6 +65,7 @@ func New(m Metrics, logger *log.Logger, opts ...LogCacheOption) *LogCache {
 		memoryLimitPercent: 50,
 		queryTimeout:       10 * time.Second,
 		truncationInterval: 500 * time.Millisecond,
+		prunesPerGC:        int64(3),
 
 		addr:     ":8080",
 		dialOpts: []grpc.DialOption{grpc.WithInsecure()},
@@ -97,6 +99,16 @@ func WithMaxPerSource(size int) LogCacheOption {
 func WithTruncationInterval(interval time.Duration) LogCacheOption {
 	return func(c *LogCache) {
 		c.truncationInterval = interval
+	}
+}
+
+// WithPrunesPerGC returns a LogCacheOption that configures the
+// number of consecutive prunes needed for garbage collection
+// to be called.
+// Defaults to 3.
+func WithPrunesPerGC(consecutivePrunes int64) LogCacheOption {
+	return func(c *LogCache) {
+		c.prunesPerGC = consecutivePrunes
 	}
 }
 
@@ -165,7 +177,7 @@ func (c *LogCache) Start() {
 		analyzer = NewMemoryAnalyzer(c.metrics)
 	}
 	p := store.NewPruneConsultant(2, c.memoryLimitPercent, analyzer)
-	store := store.NewStore(c.maxPerSource, c.truncationInterval, p, c.metrics)
+	store := store.NewStore(c.maxPerSource, c.truncationInterval, c.prunesPerGC, p, c.metrics)
 	c.setupRouting(store)
 }
 

--- a/src/internal/cache/store/store_benchmark_test.go
+++ b/src/internal/cache/store/store_benchmark_test.go
@@ -17,6 +17,7 @@ import (
 const (
 	MaxPerSource       = 1000000
 	TruncationInterval = 500 * time.Millisecond
+	PrunesPerGC        = int64(3)
 )
 
 var (
@@ -29,7 +30,7 @@ var (
 )
 
 func BenchmarkStoreWrite(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -39,7 +40,7 @@ func BenchmarkStoreWrite(b *testing.B) {
 }
 
 func BenchmarkStoreTruncationOnWrite(b *testing.B) {
-	s := store.NewStore(100, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(100, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -49,7 +50,7 @@ func BenchmarkStoreTruncationOnWrite(b *testing.B) {
 }
 
 func BenchmarkStoreWriteParallel(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	b.ResetTimer()
 
@@ -62,7 +63,7 @@ func BenchmarkStoreWriteParallel(b *testing.B) {
 }
 
 func BenchmarkStoreGetTime5MinRange(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < MaxPerSource/10; i++ {
 		e := gen()
@@ -78,7 +79,7 @@ func BenchmarkStoreGetTime5MinRange(b *testing.B) {
 }
 
 func BenchmarkStoreGetLogType(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < MaxPerSource/10; i++ {
 		e := gen()
@@ -94,7 +95,7 @@ func BenchmarkStoreGetLogType(b *testing.B) {
 }
 
 func BenchmarkMeta(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < b.N; i++ {
 		e := gen()
@@ -108,7 +109,7 @@ func BenchmarkMeta(b *testing.B) {
 }
 
 func BenchmarkMetaWhileWriting(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	ready := make(chan struct{}, 1)
 	go func() {
@@ -127,7 +128,7 @@ func BenchmarkMetaWhileWriting(b *testing.B) {
 }
 
 func BenchmarkMetaWhileReading(b *testing.B) {
-	s := store.NewStore(MaxPerSource, TruncationInterval, &staticPruner{}, nopMetrics{})
+	s := store.NewStore(MaxPerSource, TruncationInterval, PrunesPerGC, &staticPruner{}, nopMetrics{})
 
 	for i := 0; i < b.N; i++ {
 		e := gen()

--- a/src/internal/cache/store/store_benchmark_test.go
+++ b/src/internal/cache/store/store_benchmark_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	MaxPerSource       = 1000000
-	TruncationInterval = 500 * time.Millisecond
+	TruncationInterval = 1 * time.Second
 	PrunesPerGC        = int64(3)
 )
 

--- a/src/internal/cache/store/store_load_test.go
+++ b/src/internal/cache/store/store_load_test.go
@@ -25,7 +25,7 @@ var _ = Describe("store under high concurrent load", func() {
 		sp.numberToPrune = 128
 		sm := testhelpers.NewMetricsRegistry()
 
-		loadStore := store.NewStore(2500, TruncationInterval, sp, sm)
+		loadStore := store.NewStore(2500, TruncationInterval, PrunesPerGC, sp, sm)
 		start := time.Now()
 		var envelopesWritten uint64
 

--- a/src/internal/cache/store/store_test.go
+++ b/src/internal/cache/store/store_test.go
@@ -504,7 +504,7 @@ var _ = Describe("Store", func() {
 
 		Consistently(func() int64 {
 			envelopes := loadStore.Get("9", start, time.Now(), nil, nil, 100000, false)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 			return int64(len(envelopes))
 		}).Should(BeNumerically("<=", 10000))
 	})

--- a/src/internal/cache/store/store_test.go
+++ b/src/internal/cache/store/store_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Store", func() {
 	BeforeEach(func() {
 		sp = newSpyPruner()
 		sm = testhelpers.NewMetricsRegistry()
-		s = store.NewStore(5, TruncationInterval, sp, sm)
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 	})
 
 	It("fetches data based on time and source ID", func() {
@@ -78,7 +78,7 @@ var _ = Describe("Store", func() {
 
 	Context("in ascending order", func() {
 		It("respects timestamp fudging when checking the time boundaries", func() {
-			s = store.NewStore(50, TruncationInterval, sp, sm)
+			s = store.NewStore(50, TruncationInterval, PrunesPerGC, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -111,7 +111,7 @@ var _ = Describe("Store", func() {
 		})
 
 		It("intentionally exceeds the limit when it would otherwise break up a group of fudged timestamps", func() {
-			s = store.NewStore(50, TruncationInterval, sp, sm)
+			s = store.NewStore(50, TruncationInterval, PrunesPerGC, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -132,7 +132,7 @@ var _ = Describe("Store", func() {
 
 	Context("in descending order", func() {
 		It("respects timestamp fudging when checking the time boundaries", func() {
-			s = store.NewStore(50, TruncationInterval, sp, sm)
+			s = store.NewStore(50, TruncationInterval, PrunesPerGC, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -165,7 +165,7 @@ var _ = Describe("Store", func() {
 		})
 
 		It("intentionally exceeds the limit when it would otherwise break up a group of fudged timestamps", func() {
-			s = store.NewStore(50, TruncationInterval, sp, sm)
+			s = store.NewStore(50, TruncationInterval, PrunesPerGC, sp, sm)
 
 			e0 := buildEnvelope(0, "a")
 			e1 := buildEnvelope(1, "a")
@@ -313,7 +313,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("survives being over pruned", func() {
-		s = store.NewStore(10, TruncationInterval, sp, sm)
+		s = store.NewStore(10, TruncationInterval, PrunesPerGC, sp, sm)
 		e1 := buildTypedEnvelope(0, "b", &loggregator_v2.Log{})
 		s.Put(e1, e1.GetSourceId())
 		sp.SetNumberToPrune(1000)
@@ -321,7 +321,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("truncates older envelopes when max size is reached", func() {
-		s = store.NewStore(10, TruncationInterval, sp, sm)
+		s = store.NewStore(10, TruncationInterval, PrunesPerGC, sp, sm)
 		// e1 should be truncated and sourceID "b" should be forgotten.
 		e1 := buildTypedEnvelope(1, "b", &loggregator_v2.Log{})
 		// e2 should be truncated.
@@ -377,7 +377,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("truncates envelopes for a specific source-id if its max size is reached", func() {
-		s = store.NewStore(2, TruncationInterval, sp, sm)
+		s = store.NewStore(2, TruncationInterval, PrunesPerGC, sp, sm)
 		// e1 should not be truncated
 		e1 := buildTypedEnvelope(1, "b", &loggregator_v2.Log{})
 		// e2 should be truncated
@@ -414,7 +414,7 @@ var _ = Describe("Store", func() {
 	// })
 
 	It("uses the given index", func() {
-		s = store.NewStore(2, TruncationInterval, sp, sm)
+		s = store.NewStore(2, TruncationInterval, PrunesPerGC, sp, sm)
 		e := buildTypedEnvelope(0, "a", &loggregator_v2.Log{})
 		s.Put(e, "some-id")
 
@@ -426,7 +426,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("returns the indices in the store", func() {
-		s = store.NewStore(2, TruncationInterval, sp, sm)
+		s = store.NewStore(2, TruncationInterval, PrunesPerGC, sp, sm)
 
 		// Will be pruned by pruner
 		s.Put(buildTypedEnvelope(1, "index-0", &loggregator_v2.Log{}), "index-0")
@@ -468,7 +468,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("survives the just added entry from being pruned", func() {
-		s = store.NewStore(2, TruncationInterval, sp, sm)
+		s = store.NewStore(2, TruncationInterval, PrunesPerGC, sp, sm)
 
 		s.Put(buildTypedEnvelope(2, "index-0", &loggregator_v2.Log{}), "index-0")
 		s.Put(buildTypedEnvelope(3, "index-0", &loggregator_v2.Log{}), "index-0")
@@ -487,7 +487,7 @@ var _ = Describe("Store", func() {
 	It("demonstrates thread safety under heavy concurrent load", func() {
 		sp := newSpyPruner()
 		sp.SetNumberToPrune(10)
-		loadStore := store.NewStore(10000, TruncationInterval, sp, sm)
+		loadStore := store.NewStore(10000, TruncationInterval, PrunesPerGC, sp, sm)
 		start := time.Now()
 
 		for i := 0; i < 10; i++ {
@@ -507,6 +507,75 @@ var _ = Describe("Store", func() {
 			time.Sleep(500 * time.Millisecond)
 			return int64(len(envelopes))
 		}).Should(BeNumerically("<=", 10000))
+	})
+
+	It("calls garbage collect once every prunes_per_gc truncations", func() {
+
+		// Set PrunesPerGC to 2
+		s = store.NewStore(5, TruncationInterval, 2, sp, sm)
+
+		e1 := buildTypedEnvelope(1, "a", &loggregator_v2.Log{})
+		e2 := buildTypedEnvelope(2, "a", &loggregator_v2.Counter{})
+		e3 := buildTypedEnvelope(3, "a", &loggregator_v2.Gauge{})
+		e4 := buildTypedEnvelope(3, "a", &loggregator_v2.Timer{})
+
+		s.Put(e1, e1.GetSourceId())
+		s.Put(e2, e2.GetSourceId())
+		s.Put(e3, e3.GetSourceId())
+		s.Put(e4, e4.GetSourceId())
+
+		// first prune of 1 envelope won't call gc
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(1)))
+		// second consecutive prune of 1 envelope triggers gc
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(0)))
+		// next prune of 1 envelope won't call gc
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(1)))
+		// no envelopes to prune resets the counter
+		sp.SetNumberToPrune(0)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(0)))
+	})
+
+	It("doesn't call garbage collect if for less than prunes_per_gc consecutive truncations", func() {
+
+		// Set PrunesPerGC to 2
+		s = store.NewStore(5, TruncationInterval, 2, sp, sm)
+
+		e1 := buildTypedEnvelope(1, "a", &loggregator_v2.Log{})
+		e2 := buildTypedEnvelope(2, "a", &loggregator_v2.Counter{})
+		e3 := buildTypedEnvelope(3, "a", &loggregator_v2.Gauge{})
+		e4 := buildTypedEnvelope(3, "a", &loggregator_v2.Timer{})
+		e5 := buildTypedEnvelope(3, "a", &loggregator_v2.Event{})
+
+		s.Put(e1, e1.GetSourceId())
+		s.Put(e2, e2.GetSourceId())
+		s.Put(e3, e3.GetSourceId())
+		s.Put(e4, e4.GetSourceId())
+		s.Put(e5, e5.GetSourceId())
+
+		// first prune of 1 envelope won't call gc
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(1)))
+		// no envelopes to prune resets the counter
+		sp.SetNumberToPrune(0)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(0)))
+		// second prune of 1 envelope won't call gc
+		// since it wasn't consecutive
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(1)))
+		// second consecutive prune of 1 envelope triggers gc
+		sp.SetNumberToPrune(1)
+		s.WaitForTruncationToComplete()
+		Expect(s.GetConsecutiveTruncations()).To(Equal(int64(0)))
 	})
 })
 


### PR DESCRIPTION
This PR in addition to https://github.com/cloudfoundry/log-cache-release/pull/51 aims to address https://github.com/cloudfoundry/log-cache-release/issues/50.

## Summary of the issue

Log-cache determines when to delete old envelopes and how many to delete based on the amount of heap memory consumed by the cache. Deleting the envelopes from the tree doesn't actually free the memory until Go's garbage collection runs. Under some circumstances (such as under sustained high log load) log-cache will truncate the cache many times in a row before GC runs and the metric for heap used catches up. This results a large amount of the cache being dropped at once.

## Solution

This PR adds the option to run garbage collection after pruning envelopes. It also allows for operators to configure how many consecutive prunes can happen before manual garbage collection occurs.

When testing this on a small foundation (single smalll doppler) I managed to find some configurations of prune interval and prunes per GC call that resulted in log-cache sitting between 49-51% memory usage (basically pruning a few envelopes every loop) under sustained log load.

I don't believe there is a one-size-fits all solution though as the additional GC calls do impact CPU utilisation on the VM. This can be mitigated by increasing the prune interval and/or increasing the number of consecutive prunes needed for a GC. Setting the former too high results in cache not being pruned enough and the VM getting OOM-killed. Setting the latter too high makes it ineffective as the automatic GC will run first.

This means any configuration would depend on the expected log throughput, the size of the doppler VMs, and the relative cost to cache-life sensitivity (maybe scaling CPU vertically is worth having less envelopes suddenly pruned).

This PR and my previous one aim to give operators two levers to play with in order to find an acceptable balance between memory usage, CPU utilisation, and cache truncation for their environments/log loads.

The new GC setting defaults to being disabled so this PR should have no impact on existing deployments.