### PR TITLE
Add mTLS to metrics endpoint for nozzle

### DIFF
--- a/jobs/log-cache-nozzle/spec
+++ b/jobs/log-cache-nozzle/spec
@@ -10,6 +10,9 @@ templates:
   log_cache.crt.erb: config/certs/log_cache.crt
   log_cache.key.erb: config/certs/log_cache.key
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
+  metrics_ca.crt.erb: config/certs/metrics_ca.crt
+  metrics.crt.erb: config/certs/metrics.crt
+  metrics.key.erb: config/certs/metrics.key
 
 packages:
 - log-cache-nozzle
@@ -35,9 +38,6 @@ properties:
   logs_provider.tls.key:
     description: "TLS key for the logs-provider connection"
 
-  health_port:
-    description: "The port for the Nozzle to bind a health endpoint"
-    default: 6061
   shard_id:
     description: "The sharding group name to use for egress from RLP"
     default: "log-cache"
@@ -50,3 +50,15 @@ properties:
     default: "deprecated"
   rlp.override_address:
     description: "Override of bosh links for reverse-log-proxy url"
+
+  metrics.port:
+    description: "The port for the nozzle to bind a health endpoint"
+    default: 6061
+  metrics.ca_cert:
+    description: "TLS CA cert to verify requests to metrics endpoint."
+  metrics.cert:
+    description: "TLS certificate for metrics server signed by the metrics CA"
+  metrics.key:
+    description: "TLS private key for metrics server signed by the metrics CA"
+  metrics.server_name:
+    description: "The server name used in the scrape configuration for the metrics endpoint"

--- a/jobs/log-cache-nozzle/templates/bpm.yml.erb
+++ b/jobs/log-cache-nozzle/templates/bpm.yml.erb
@@ -15,8 +15,6 @@ processes:
 - name: log-cache-nozzle
   executable: /var/vcap/packages/log-cache-nozzle/log-cache-nozzle
   env:
-    HEALTH_PORT: "<%= p('health_port') %>"
-
     # Logs Provider
     LOGS_PROVIDER_ADDR: "<%= "#{rlp_address}:#{rlp.p('reverse_log_proxy.egress.port')}" %>"
     LOGS_PROVIDER_CA_FILE_PATH:   "<%= "#{certDir}/logs_provider_ca.crt" %>"
@@ -32,6 +30,11 @@ processes:
     SELECTORS:      "<%= p('selectors').join(',') %>"
     GODEBUG: "x509ignoreCN=0"
     USE_RFC339: "<%= p("logging.format.timestamp") == "rfc3339" %>"
+
+    METRICS_PORT: <%= p("metrics.port") %>
+    METRICS_CA_FILE_PATH: "<%= "#{certDir}/metrics_ca.crt" %>"
+    METRICS_CERT_FILE_PATH: "<%= "#{certDir}/metrics.crt" %>"
+    METRICS_KEY_FILE_PATH: "<%= "#{certDir}/metrics.key" %>"
 
   limits:
     open_files: 8192

--- a/jobs/log-cache-nozzle/templates/metrics.crt.erb
+++ b/jobs/log-cache-nozzle/templates/metrics.crt.erb
@@ -1,0 +1,1 @@
+<%= p("metrics.cert") %>

--- a/jobs/log-cache-nozzle/templates/metrics.key.erb
+++ b/jobs/log-cache-nozzle/templates/metrics.key.erb
@@ -1,0 +1,1 @@
+<%= p("metrics.key") %>

--- a/jobs/log-cache-nozzle/templates/metrics_ca.crt.erb
+++ b/jobs/log-cache-nozzle/templates/metrics_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p("metrics.ca_cert") %>

--- a/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
+++ b/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
 ---
-port: <%= p('health_port') %>
+port: <%= p('metrics.port') %>
 source_id: log-cache-nozzle
 instance_id: <%= spec.id || spec.index.to_s %>
+scheme: https
+server_name: <%= p('metrics.server_name') %>
 labels:
   job: log_cache_nozzle

--- a/src/cmd/nozzle/config.go
+++ b/src/cmd/nozzle/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	envstruct "code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/log-cache/internal/config"
 	"code.cloudfoundry.org/log-cache/internal/tls"
 )
 
@@ -11,12 +12,12 @@ type Config struct {
 	LogsProviderTLS LogsProviderTLS
 
 	LogCacheAddr string   `env:"LOG_CACHE_ADDR, required, report"`
-	HealthPort   int      `env:"HEALTH_PORT, report"`
 	ShardId      string   `env:"SHARD_ID, required, report"`
 	Selectors    []string `env:"SELECTORS, required, report"`
 
-	LogCacheTLS tls.TLS
-	UseRFC339   bool `env:"USE_RFC339"`
+	LogCacheTLS   tls.TLS
+	MetricsServer config.MetricsServer
+	UseRFC339     bool `env:"USE_RFC339"`
 }
 
 // LogsProviderTLS is the LogsProviderTLS configuration for a LogCache.
@@ -30,9 +31,11 @@ type LogsProviderTLS struct {
 func LoadConfig() (*Config, error) {
 	c := Config{
 		LogCacheAddr: ":8080",
-		HealthPort:   6061,
 		ShardId:      "log-cache",
 		Selectors:    []string{"log", "gauge", "counter", "timer", "event"},
+		MetricsServer: config.MetricsServer{
+			Port: 6061,
+		},
 	}
 
 	if err := envstruct.Load(&c); err != nil {


### PR DESCRIPTION
Addresses https://github.com/cloudfoundry/log-cache-release/issues/48 and possibly https://github.com/cloudfoundry/log-cache-release/issues/42 (though I'm not sure how to confirm that one).

[Prom Scraper](https://github.com/cloudfoundry/loggregator-agent-release/blob/develop/docs/prom-scraper.md) requires mTLS to work properly but the log-cache-nozzle job was never updated to provide the appropriate certs. This PR brings it in line with the other log-cache components. I've mostly just implemented the changes to `log-cache` from [this commit](https://github.com/cloudfoundry/log-cache-release/commit/b4f2453ef904ee970037484aca5e7f840e98eca6#diff-4f7b7098137d8292a6dfaa8de46a1d7b77f9b6b744746bdfe821a7d733aa06bc) for `log-cache-nozzle`.

This is a breaking change as deployment manifests will need to be updated to provide the certs. In my test env these operations were sufficient ([`metric_scraper_ca` already exists in cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/main/cf-deployment.yml#L2479)):

```
- type: replace
  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/properties/metrics?
  value:
    ca_cert: ((log_cache_nozzle_metrics_tls.ca))
    cert: ((log_cache_nozzle_metrics_tls.certificate))
    key: ((log_cache_nozzle_metrics_tls.private_key))
    server_name: log_cache_nozzle_metrics

- type: replace
  path: /variables/name=log_cache_nozzle_metrics_tls?
  value:
    name: log_cache_nozzle_metrics_tls
    type: certificate
    update_mode: converge
    options:
      ca: metric_scraper_ca
      common_name: log_cache_nozzle_metrics
      alternative_names:
      - log_cache_nozzle_metrics
      extended_key_usage:
      - server_auth
```

I'm happy to open a PR to cf-deployment with these additions but I don't know how coordination works between new releases of log-cache-release and new releases of cf-deployment. Let me know what the best approach is.

Before the change:
```
$ cf log-meta
Source                                                   Source Type  Count  Expired  Cache Duration
...
log-cache                                                platform     1008   0        17m0s
log-cache-cf-auth-proxy                                  platform     810    0        17m0s
log-cache-gateway                                        platform     756    0        17m0s
...
```

After the change:
```
$ cf log-meta
Source                                                   Source Type  Count  Expired  Cache Duration
...
log-cache                                                platform     1008   0        17m0s
log-cache-cf-auth-proxy                                  platform     810    0        17m0s
log-cache-gateway                                        platform     756    0        17m0s
log-cache-nozzle                                         platform     322    0        5m59s
...
```

```
$ cf tail log-cache-nozzle -t counter
Retrieving logs for source log-cache-nozzle as $user...

   2021-09-30T15:57:51.62+0000 [log-cache-nozzle/7976f511-55ae-4702-82df-031d478c4100] COUNTER nozzle_egress:2505334
   2021-09-30T15:57:51.62+0000 [log-cache-nozzle/7976f511-55ae-4702-82df-031d478c4100] COUNTER nozzle_err:0
   2021-09-30T15:57:51.62+0000 [log-cache-nozzle/7976f511-55ae-4702-82df-031d478c4100] COUNTER nozzle_dropped:0
   2021-09-30T15:57:51.62+0000 [log-cache-nozzle/7976f511-55ae-4702-82df-031d478c4100] COUNTER nozzle_ingress:2505374
```