### PR TITLE
fix prom scraper config

### DIFF
--- a/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
+++ b/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
@@ -1,3 +1,4 @@
+<% if p('enabled') %>
 ---
 port: <%= p('metrics.port') %>
 source_id: log-cache-nozzle
@@ -6,3 +7,4 @@ scheme: https
 server_name: <%= p('metrics.server_name') %>
 labels:
   job: log_cache_nozzle
+<% end %>

--- a/jobs/log-cache-syslog-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/log-cache-syslog-server/templates/prom_scraper_config.yml.erb
@@ -1,3 +1,4 @@
+<% if p('enabled') %>
 ---
 port: <%= p('metrics.port') %>
 source_id: log-cache-syslog-server
@@ -6,3 +7,4 @@ scheme: https
 server_name: <%= p('metrics.server_name') %>
 labels:
   job: log_cache_syslog_server
+<% end %>

--- a/spec/log_cache_nozzle_spec.rb
+++ b/spec/log_cache_nozzle_spec.rb
@@ -81,6 +81,31 @@ describe 'log-cache-nozzle job' do
     end
   end
 
+  describe 'prom_scraper_config.yml' do
+    let(:template) { job.template('config/prom_scraper_config.yml') }
+
+    it 'is a empty file when not enabled' do
+      properties = {
+        'enabled' => false
+      }
+
+      actual = template.render(properties)
+      expect(actual).to eq("\n")
+    end
+    it 'renders correctly when enabled' do
+      properties = {
+        'enabled' => true,
+        'metrics' => {
+          'port' => 55,
+          'server_name' => 'server-name'
+        }
+      }
+      actual = YAML.safe_load(template.render(properties))
+      expect(actual['port']).to equal(55)
+      expect(actual['server_name']).to eq("server-name")
+    end
+  end
+
   describe 'bpm.yml' do
     let(:template) { job.template('config/bpm.yml') }
     let(:links) do


### PR DESCRIPTION
- do not render prom scraper config when syslog server or nozzle is not run
- bringing up to date with new patterns for optional prom scraping in new releases of loggregator-agent and metrics-discovery

Signed-off-by: Ben Fuller <benjaminf@vmware.com>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

