### PR TITLE
fix prom scraper config

### DIFF
--- a/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
+++ b/jobs/log-cache-nozzle/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,8 @@
+<% if p('enabled') %>
 ---
 port: <%= p('health_port') %>
 source_id: log-cache-nozzle
 instance_id: <%= spec.id || spec.index.to_s %>
 labels:
   job: log_cache_nozzle
+<% end %>

--- a/jobs/log-cache-syslog-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/log-cache-syslog-server/templates/prom_scraper_config.yml.erb
@@ -1,3 +1,4 @@
+<% if p('enabled') %>
 ---
 port: <%= p('metrics.port') %>
 source_id: log-cache-syslog-server
@@ -6,3 +7,4 @@ scheme: https
 server_name: <%= p('metrics.server_name') %>
 labels:
   job: log_cache_syslog_server
+<% end %>


### PR DESCRIPTION
- do not render prom scraper config when syslog server or nozzle is not run
- bringing up to date with new patterns for optional prom scraping in new releases of loggregator-agent and metrics-discovery

Signed-off-by: Ben Fuller <benjaminf@vmware.com>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

