### PR TITLE
Fix: go test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - run: go run github.com/onsi/ginkgo/ginkgo -r -p -race -randomizeAllSpecs -randomizeSuites
+      - run: go run github.com/onsi/ginkgo/ginkgo -r -race -randomizeAllSpecs -randomizeSuites
         working-directory: src
 
   vet:


### PR DESCRIPTION
It doesn't seem like this repo is ready for parallel unit tests. That's
something we can come back to, and for now we don't lose much time by
running them serially.
