### PR TITLE
Fixes concurrency bug in store test suite

### DIFF
--- a/src/internal/cache/store/store_test.go
+++ b/src/internal/cache/store/store_test.go
@@ -28,10 +28,10 @@ var _ = Describe("Store", func() {
 	BeforeEach(func() {
 		sp = newSpyPruner()
 		sm = testhelpers.NewMetricsRegistry()
-		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 	})
 
 	It("fetches data based on time and source ID", func() {
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 		e1 := buildEnvelope(1, "a")
 		e2 := buildEnvelope(2, "b")
 		e3 := buildEnvelope(3, "a")
@@ -57,6 +57,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("returns a maximum number of envelopes in ascending order", func() {
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 		e1 := buildEnvelope(1, "a")
 		e2 := buildEnvelope(2, "a")
 		e3 := buildEnvelope(3, "a")
@@ -185,6 +186,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("returns a maximum number of envelopes in descending order", func() {
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 		e1 := buildEnvelope(1, "a")
 		e2 := buildEnvelope(2, "a")
 		e3 := buildEnvelope(3, "a")
@@ -205,6 +207,7 @@ var _ = Describe("Store", func() {
 	})
 
 	It("increments the timestamp as necessary to prevent overwrites", func() {
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 		e1 := buildEnvelope(1, "a")
 		e2 := buildEnvelope(1, "a")
 		e3 := buildEnvelope(3, "a")
@@ -221,6 +224,7 @@ var _ = Describe("Store", func() {
 
 	DescribeTable("fetches data based on envelope type",
 		func(envelopeType logcache_v1.EnvelopeType, envelopeWrapper interface{}) {
+			s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 			e1 := buildTypedEnvelope(1, "a", &loggregator_v2.Log{})
 			e2 := buildTypedEnvelope(2, "a", &loggregator_v2.Counter{})
 			e3 := buildTypedEnvelope(3, "a", &loggregator_v2.Gauge{})
@@ -253,6 +257,7 @@ var _ = Describe("Store", func() {
 
 	DescribeTable("fetches data based on metric name",
 		func(nameFilter, expectedName string) {
+			s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 			filter := regexp.MustCompile(nameFilter)
 
 			e1 := buildTypedEnvelopeWithName(1, "counter-metric-name", &loggregator_v2.Counter{})
@@ -291,6 +296,7 @@ var _ = Describe("Store", func() {
 	)
 
 	It("is thread safe", func() {
+		s = store.NewStore(5, TruncationInterval, PrunesPerGC, sp, sm)
 		var wg sync.WaitGroup
 		wg.Add(2)
 		defer wg.Wait()


### PR DESCRIPTION
This commit changes the Store creation logic in the tests so that the
tests will never have multiple Stores accessing the same Metrics
Registry at the same time.

Prior to this commit, some tests (but most notably the "truncates older
envelopes when max size is reached" test) will -when waiting to data
values out of the Metrics Registry- will sometimes get values for the
wrong Registry.

Signed-off-by: Matthew Kocher <mkocher@vmware.com>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes
