### PR TITLE
Add optional mTLS for the log-cache-syslog-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Log Cache is known to exceed memory limits under high throughput/stress. If you 
 then you have set, you might want to scale your log-cache up. Either solely in terms of CPU per instance, or more instances.
 
 You can monitor the performance of log cache per source id (app or platform component) using the Log Cache CLI. The command `cf log-meta` allows viewing
-the amount of logs and metrics as well as the period of time for those logs and metrics for each source on the system. This can be used in conjuction with scaling
+the amount of logs and metrics as well as the period of time for those logs and metrics for each source on the system. This can be used in conjunction with scaling
 to target your use cases. For simple pushes, a low retention period may be adequate. For running analysis on metrics for debugging and scaling, higher retention
 periods may be desired; although one should remember all logs and metrics will always be lost upon crashes or re-deploys of log-cache.
+
+### Log Cache Syslog Server TLS and mutual TLS configuration
+
+If someone runs Cloud Foundry with a hardened setup in terms of security, they might want to activate TLS or even mutual TLS(mTLS) for the incoming connections to the Log Cache Syslog Server. The activation of TLS and mTLS is optional and is configured by the presence of the needed certificates. For TLS a syslog certificate or syslog key should be present in the BPM configuration and for mTLS a syslog client CA certificate should be present in the BPM configuration. Check the BOSH [BPM template](jobs/log-cache-syslog-server/templates/bpm.yml.erb) and the [spec](jobs/log-cache-syslog-server/spec) for details.
 
 ### Reliability
 

--- a/jobs/log-cache-syslog-server/spec
+++ b/jobs/log-cache-syslog-server/spec
@@ -6,6 +6,7 @@ templates:
   log_cache_ca.crt.erb: config/certs/log_cache_ca.crt
   log_cache.crt.erb: config/certs/log_cache.crt
   log_cache.key.erb: config/certs/log_cache.key
+  syslog_client_ca.crt.erb: config/certs/syslog_client_ca.crt
   syslog.crt.erb: config/certs/syslog.crt
   syslog.key.erb: config/certs/syslog.key
   prom_scraper_config.yml.erb: config/prom_scraper_config.yml
@@ -34,6 +35,9 @@ properties:
   syslog_idle_timeout:
     description: "Timeout for the Syslog Server connection"
     default: "2m"
+
+  syslog_client_ca_cert:
+    description: The CA certificate for key/cert verification.
 
   metrics.port:
     description: "The port for the Syslog Server to bind a health endpoint"

--- a/jobs/log-cache-syslog-server/templates/bpm.yml.erb
+++ b/jobs/log-cache-syslog-server/templates/bpm.yml.erb
@@ -2,6 +2,11 @@
   jobDir = "/var/vcap/jobs/log-cache-syslog-server"
   certDir = "#{jobDir}/config/certs"
 
+  syslog_client_ca=""
+  if_p("syslog_client_ca_cert") {
+    syslog_client_ca="#{certDir}/syslog_client_ca.crt"
+  }
+
   lc = link("log-cache")
 %>
 ---
@@ -14,6 +19,8 @@ processes:
 
     SYSLOG_TLS_CERT_PATH: "<%= "#{certDir}/syslog.crt" %>"
     SYSLOG_TLS_KEY_PATH: "<%= "#{certDir}/syslog.key" %>"
+
+    SYSLOG_CLIENT_TRUSTED_CA_FILE: "<%= "#{syslog_client_ca}" %>"
 
     LOG_CACHE_ADDR: "<%= "localhost:#{lc.p('port')}" %>"
     CA_PATH:        "<%= "#{certDir}/log_cache_ca.crt" %>"

--- a/jobs/log-cache-syslog-server/templates/syslog_client_ca.crt.erb
+++ b/jobs/log-cache-syslog-server/templates/syslog_client_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p("syslog_client_ca_cert", "") %>

--- a/spec/log_cache_syslog_server_spec.rb
+++ b/spec/log_cache_syslog_server_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'bosh/template/test'
+require_relative 'spec_helper'
+
+describe 'log-cache-syslog-server job' do
+  let(:release_dir) { File.join(File.dirname(__FILE__), '..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_dir) }
+  let(:job) { release.job('log-cache-syslog-server') }
+
+  describe 'syslog_client_ca.crt' do
+    let(:template) { job.template('config/certs/syslog_client_ca.crt') }
+
+    it 'can render the template' do
+      properties = {
+        'syslog_client_ca_cert' => 'syslog_client_ca_cert'
+      }
+
+      actual = template.render(properties)
+      expect(actual).to match('syslog_client_ca_cert')
+    end
+  end
+
+  describe 'syslog.crt' do
+    let(:template) { job.template('config/certs/syslog.crt') }
+
+    it 'can render the template' do
+      properties = {
+        'tls' => {
+          'cert' => 'cert'
+        }
+      }
+
+      actual = template.render(properties)
+      expect(actual).to match('cert')
+    end
+  end
+
+  describe 'syslog.key' do
+    let(:template) { job.template('config/certs/syslog.key') }
+
+    it 'can render the template' do
+      properties = {
+        'tls' => {
+          'key' => 'key'
+        }
+      }
+
+      actual = template.render(properties)
+      expect(actual).to match('key')
+    end
+  end
+
+  describe 'bpm.yml' do
+    let(:template) { job.template('config/bpm.yml') }
+    let(:links) do
+      [
+        Bosh::Template::Test::Link.new(
+          name: 'log-cache',
+          properties: {
+            'port' => 8080
+          }
+        )
+      ]
+    end
+
+    it 'contains the tls configuration for the syslog server' do
+      certPath = "/var/vcap/jobs/log-cache-syslog-server/config/certs"
+      properties = {
+        'syslog_client_ca_cert' => "#{certPath}/syslog_client_ca.crt"
+      }
+      bpm_yml = YAML.safe_load(template.render(properties, consumes: links))
+      env = bpm_process(bpm_yml, 0)['env']
+
+      expect(env).to include('SYSLOG_CLIENT_TRUSTED_CA_FILE')
+      expect(env).to include('SYSLOG_TLS_CERT_PATH')
+      expect(env).to include('SYSLOG_TLS_KEY_PATH')
+      expect(env.fetch("SYSLOG_CLIENT_TRUSTED_CA_FILE")).to eq("#{certPath}/syslog_client_ca.crt")
+      expect(env.fetch("SYSLOG_TLS_CERT_PATH")).to eq("#{certPath}/syslog.crt")
+      expect(env.fetch("SYSLOG_TLS_KEY_PATH")).to eq("#{certPath}/syslog.key")
+    end
+  end
+end

--- a/src/cmd/syslog-server/config.go
+++ b/src/cmd/syslog-server/config.go
@@ -13,14 +13,18 @@ type Config struct {
 	LogCacheAddr string `env:"LOG_CACHE_ADDR, required, report"`
 	SyslogPort   int    `env:"SYSLOG_PORT, required, report"`
 
-	LogCacheTLS       tls.TLS
+	LogCacheTLS tls.TLS
+
 	SyslogTLSCertPath string `env:"SYSLOG_TLS_CERT_PATH, report"`
 	SyslogTLSKeyPath  string `env:"SYSLOG_TLS_KEY_PATH, report"`
 
 	SyslogIdleTimeout      time.Duration `env:"SYSLOG_IDLE_TIMEOUT, report"`
 	SyslogMaxMessageLength int           `env:"SYSLOG_MAX_MESSAGE_LENGTH, report"`
-	MetricsServer          config.MetricsServer
-	UseRFC339              bool `env:"USE_RFC339"`
+
+	SyslogClientTrustedCAFile string `env:"SYSLOG_CLIENT_TRUSTED_CA_FILE,  report"`
+
+	MetricsServer config.MetricsServer
+	UseRFC339     bool `env:"USE_RFC339"`
 }
 
 // LoadConfig creates Config object from environment variables

--- a/src/cmd/syslog-server/main.go
+++ b/src/cmd/syslog-server/main.go
@@ -70,6 +70,9 @@ func main() {
 	if cfg.SyslogTLSCertPath != "" || cfg.SyslogTLSKeyPath != "" {
 		serverOptions = append(serverOptions, syslog.WithServerTLS(cfg.SyslogTLSCertPath, cfg.SyslogTLSKeyPath))
 	}
+	if cfg.SyslogClientTrustedCAFile != "" {
+		serverOptions = append(serverOptions, syslog.WithSyslogClientCA(cfg.SyslogClientTrustedCAFile))
+	}
 
 	server := syslog.NewServer(
 		loggr,


### PR DESCRIPTION
# Description

Activates mutual TLS in the log-cache-syslog-server. All of the incoming syslog connections will be verified, if a syslog client CA certificate is configured. The goal is to give an option to the users to harden the communication between the Syslog Agents running on all BOSH VMs and the Log-Cache Syslog Server and secure it with mutual TLS.

Changes:
- adjust BOSH job templates and add a field for syslog client CA
- configure the log-cache-syslog-server to use mTLS in case a the syslog client CA is configured
- add test for log-cache-syslog-server mTLS configuration
- update README.md add paragraph about TLS and mTLS configuration for the log-cache-syslog-server

As I haven't found any specific details about configuring Log-Cache in the [Logging and Metrics Architecture](https://docs.cloudfoundry.org/loggregator/architecture.html), I've added a paragraph about configuring TLS or mTLS in the [README.md](README.md). I'm not sure if some other documentation should be updated.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [X] I have made corresponding changes to the documentation
- [X] I have added testing for my changes
