### PR TITLE
Fix linting

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,6 +1,11 @@
+run:
+  # Timeout for analysis.
+  # Default: 1m.
+  timeout: 5m
+
 linters:
   enable:
-    # Checks for non-ASCII identifiers
+    # Checks for non-ASCII identifiers.
     - asciicheck
     # Computes and checks the cyclomatic complexity of functions.
     - gocyclo

--- a/src/cmd/cf-auth-proxy/main.go
+++ b/src/cmd/cf-auth-proxy/main.go
@@ -6,7 +6,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+
+	//nolint:gosec
 	_ "net/http/pprof"
+
 	"net/url"
 	"os"
 	"time"
@@ -44,7 +47,10 @@ func main() {
 	loggr.Print("Starting Log Cache CF Auth Reverse Proxy...")
 	defer loggr.Print("Closing Log Cache CF Auth Reverse Proxy.")
 
-	envstruct.WriteReport(cfg)
+	err = envstruct.WriteReport(cfg)
+	if err != nil {
+		log.Printf("Failed to print a report of the from environment: %s\n", err)
+	}
 	metricServerOption := metrics.WithTLSServer(
 		int(cfg.MetricsServer.Port),
 		cfg.MetricsServer.CertFile,
@@ -149,6 +155,8 @@ func main() {
 		if err != nil {
 			loggr.Panicf("Unable to open access log: %s", err)
 		}
+
+		//nolint:errcheck
 		defer func() {
 			accessLog.Sync()
 			accessLog.Close()

--- a/src/cmd/gateway/config.go
+++ b/src/cmd/gateway/config.go
@@ -37,7 +37,10 @@ func LoadConfig() (*Config, error) {
 
 	c.Version = buildVersion
 
-	envstruct.WriteReport(&c)
+	err := envstruct.WriteReport(&c)
+	if err != nil {
+		return nil, err
+	}
 
 	return &c, nil
 }

--- a/src/cmd/gateway/main.go
+++ b/src/cmd/gateway/main.go
@@ -9,11 +9,14 @@ import (
 	metrics "code.cloudfoundry.org/go-metric-registry"
 
 	"net/http"
+
+	//nolint: gosec
 	_ "net/http/pprof"
 
 	. "code.cloudfoundry.org/log-cache/internal/gateway"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -79,7 +82,7 @@ func main() {
 		)
 	} else {
 		gatewayOptions = append(gatewayOptions, WithGatewayLogCacheDialOpts(
-			grpc.WithInsecure(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50*1024*1024)),
 		),
 		)

--- a/src/cmd/nozzle/main.go
+++ b/src/cmd/nozzle/main.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	//nolint:gosec
 	_ "net/http/pprof"
+
 	"os"
 	"os/signal"
 	"syscall"
@@ -40,7 +43,10 @@ func main() {
 	log.Print("Starting LogCache Nozzle...")
 	defer log.Print("Closing LogCache Nozzle.")
 
-	envstruct.WriteReport(cfg)
+	err = envstruct.WriteReport(cfg)
+	if err != nil {
+		log.Printf("Failed to print a report of the from environment: %s\n", err)
+	}
 
 	metricServerOption := metrics.WithTLSServer(
 		int(cfg.MetricsServer.Port),

--- a/src/internal/auth/access_log_test.go
+++ b/src/internal/auth/access_log_test.go
@@ -1,8 +1,11 @@
 package auth_test
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"log"
+	"math"
+	"math/big"
 	"net/http"
 	"strconv"
 	"time"
@@ -39,16 +42,25 @@ var _ = Describe("AccessLog", func() {
 		timestamp = time.Now()
 
 		method = "GET"
-		path = fmt.Sprintf("/some/path?with_query=params-%d", rand.Int())
-		url = "http://example.com" + path
-		sourceHost = fmt.Sprintf("10.0.1.%d", rand.Int()%256)
-		sourcePort = strconv.Itoa(rand.Int()%65535 + 1)
-		remoteAddr = sourceHost + ":" + sourcePort
-		dstHost = fmt.Sprintf("10.1.2.%d", rand.Int()%256)
-		dstPort = strconv.Itoa(rand.Int()%65535 + 1)
 
-		forwardedFor = fmt.Sprintf("10.0.0.%d", rand.Int()%256)
-		requestId = fmt.Sprintf("test-vcap-request-id-%d", rand.Int())
+		getRandomNumber := func() int {
+			nBig, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
+			if err != nil {
+				log.Fatalf("Cannot generate random number %v", err)
+			}
+			return int(nBig.Int64())
+		}
+
+		path = fmt.Sprintf("/some/path?with_query=params-%d", getRandomNumber())
+		url = "http://example.com" + path
+		sourceHost = fmt.Sprintf("10.0.1.%d", getRandomNumber()%256)
+		sourcePort = strconv.Itoa(getRandomNumber()%65535 + 1)
+		remoteAddr = sourceHost + ":" + sourcePort
+		dstHost = fmt.Sprintf("10.1.2.%d", getRandomNumber()%256)
+		dstPort = strconv.Itoa(getRandomNumber()%65535 + 1)
+
+		forwardedFor = fmt.Sprintf("10.0.0.%d", getRandomNumber()%256)
+		requestId = fmt.Sprintf("test-vcap-request-id-%d", getRandomNumber())
 	})
 
 	JustBeforeEach(func() {

--- a/src/internal/auth/capi_client.go
+++ b/src/internal/auth/capi_client.go
@@ -312,6 +312,7 @@ func cleanup(resp *http.Response) {
 		return
 	}
 
+	//nolint:errcheck
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 }

--- a/src/internal/auth/cf_auth_middleware.go
+++ b/src/internal/auth/cf_auth_middleware.go
@@ -117,11 +117,14 @@ func (m CFAuthMiddlewareProvider) Middleware(h http.Handler) http.Handler {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 
-			json.NewEncoder(w).Encode(&promqlErrorBody{
+			err = json.NewEncoder(w).Encode(&promqlErrorBody{
 				Status:    "error",
 				ErrorType: "bad_data",
 				Error:     err.Error(),
 			})
+			if err != nil {
+				log.Printf("bad data: %v\n", err)
+			}
 
 			return
 		}
@@ -130,11 +133,14 @@ func (m CFAuthMiddlewareProvider) Middleware(h http.Handler) http.Handler {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 
-			json.NewEncoder(w).Encode(&promqlErrorBody{
+			err = json.NewEncoder(w).Encode(&promqlErrorBody{
 				Status:    "error",
 				ErrorType: "bad_data",
 				Error:     "query does not request any source_ids",
 			})
+			if err != nil {
+				log.Println("bad_data: query does not request any source_ids")
+			}
 
 			return
 		}
@@ -206,7 +212,9 @@ func (m CFAuthMiddlewareProvider) Middleware(h http.Handler) http.Handler {
 		msg, _ := protojson.Marshal(&rpc.MetaResponse{
 			Meta: m.onlyAuthorized(authToken, meta, c),
 		})
+		//nolint:errcheck
 		w.Write(msg)
+		//nolint:errcheck
 		w.Write([]byte("\n"))
 	})
 

--- a/src/internal/auth/cf_auth_middleware_test.go
+++ b/src/internal/auth/cf_auth_middleware_test.go
@@ -397,8 +397,6 @@ var _ = Describe("CfAuthMiddleware", func() {
 type spyOauth2ClientReader struct {
 	token         string
 	isAdminResult bool
-	client        string
-	user          string
 	err           error
 }
 

--- a/src/internal/auth/uaa_client.go
+++ b/src/internal/auth/uaa_client.go
@@ -217,7 +217,7 @@ func (c *UAAClient) Read(token string) (Oauth2ClientContext, error) {
 			// which generally means we've tried to decode a token with the
 			// wrong private key. just in case UAA has rolled the key, but
 			// kept the same keyId, let's renew our keys.
-			go c.RefreshTokenKeys()
+			go c.RefreshTokenKeys() //nolint:errcheck
 		}
 
 		return Oauth2ClientContext{}, fmt.Errorf("failed to decode token: %s", err.Error())
@@ -252,7 +252,7 @@ func (c *UAAClient) loadOrFetchPublicKey(keyId string) (interface{}, error) {
 		return publicKey, nil
 	}
 
-	c.RefreshTokenKeys()
+	c.RefreshTokenKeys() //nolint:errcheck
 
 	publicKey, ok = c.publicKeys.Load(keyId)
 	if ok {

--- a/src/internal/cache/log_cache.go
+++ b/src/internal/cache/log_cache.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	client "code.cloudfoundry.org/go-log-cache"
 	"code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
@@ -68,7 +69,7 @@ func New(m Metrics, logger *log.Logger, opts ...LogCacheOption) *LogCache {
 		prunesPerGC:        int64(3),
 
 		addr:     ":8080",
-		dialOpts: []grpc.DialOption{grpc.WithInsecure()},
+		dialOpts: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 	}
 
 	for _, o := range opts {

--- a/src/internal/cache/memory_analyzer.go
+++ b/src/internal/cache/memory_analyzer.go
@@ -51,6 +51,8 @@ func (a *MemoryAnalyzer) Memory() (heapInUse, total uint64) {
 	defer a.Unlock()
 
 	var m sigar.Mem
+
+	//nolint:errcheck
 	m.Get()
 
 	a.avail = m.ActualFree

--- a/src/internal/cache/store/store.go
+++ b/src/internal/cache/store/store.go
@@ -547,7 +547,7 @@ func (store *Store) Meta() map[string]logcache_v1.MetaInfo {
 
 	// Range over our local copy of metaReport
 	// TODO - shouldn't we just maintain Count on metaReport..?!
-	for sourceId, _ := range metaReport {
+	for sourceId := range metaReport {
 		tree, _ := store.storageIndex.Load(sourceId)
 
 		tree.(*storage).RLock()

--- a/src/internal/cache/store/store_benchmark_test.go
+++ b/src/internal/cache/store/store_benchmark_test.go
@@ -1,9 +1,9 @@
 package store_test
 
 import (
-	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"testing"
 	"time"
 
@@ -151,15 +151,6 @@ func BenchmarkMetaWhileReading(b *testing.B) {
 	}
 }
 
-func contextIsDone(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	default:
-		return false
-	}
-}
-
 func randEnvGen() func() *loggregator_v2.Envelope {
 	var s []*loggregator_v2.Envelope
 	fiveMinAgo := time.Now().Add(-5 * time.Minute)
@@ -178,10 +169,15 @@ func randEnvGen() func() *loggregator_v2.Envelope {
 }
 
 func benchBuildLog(appID string, ts int64) *loggregator_v2.Envelope {
+
+	nBig, err := rand.Int(rand.Reader, big.NewInt(50))
+	if err != nil {
+		return nil
+	}
 	return &loggregator_v2.Envelope{
 		SourceId: appID,
 		// Timestamp: ts,
-		Timestamp: time.Now().Add(time.Duration(rand.Int63n(50)-100) * time.Microsecond).UnixNano(),
+		Timestamp: time.Now().Add(time.Duration(int(nBig.Int64())-100) * time.Microsecond).UnixNano(),
 		Message: &loggregator_v2.Envelope_Log{
 			Log: &loggregator_v2.Log{},
 		},

--- a/src/internal/cfauthproxy/cf_auth_proxy.go
+++ b/src/internal/cfauthproxy/cf_auth_proxy.go
@@ -180,7 +180,8 @@ func NewTransportWithRootCA(rootCACertPool *x509.CertPool) *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			RootCAs: rootCACertPool,
+			MinVersion: tls.VersionTLS12, //nolint:gosec
+			RootCAs:    rootCACertPool,
 		},
 	}
 }

--- a/src/internal/cfauthproxy/cf_auth_proxy_test.go
+++ b/src/internal/cfauthproxy/cf_auth_proxy_test.go
@@ -86,7 +86,8 @@ var _ = Describe("CFAuthProxy", func() {
 
 		testServer := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				w.Write([]byte("Insecure Gateway not allowed"))
+				_, err := w.Write([]byte("Insecure Gateway not allowed"))
+				Expect(err).ToNot(HaveOccurred())
 			}))
 		defer testServer.Close()
 
@@ -243,7 +244,8 @@ func newInsecureCFAuthProxy(gatewayURL string, opts ...CFAuthProxyOption) *CFAut
 func startSecureGateway(responseBody string) *httptest.Server {
 	testGateway := httptest.NewUnstartedServer(
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte(responseBody))
+			_, err := w.Write([]byte(responseBody))
+			Expect(err).ToNot(HaveOccurred())
 		}),
 	)
 
@@ -253,6 +255,7 @@ func startSecureGateway(responseBody string) *httptest.Server {
 	}
 
 	testGateway.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		RootCAs:      localhostCerts.Pool(),
 		Certificates: []tls.Certificate{cert},
 	}
@@ -265,7 +268,8 @@ func startSecureGateway(responseBody string) *httptest.Server {
 func startGateway(responseBody string) *httptest.Server {
 	testGateway := httptest.NewUnstartedServer(
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte(responseBody))
+			_, err := w.Write([]byte(responseBody))
+			Expect(err).ToNot(HaveOccurred())
 		}),
 	)
 
@@ -279,7 +283,7 @@ func makeTLSReq(addr string) (*http.Response, error) {
 	Expect(err).ToNot(HaveOccurred())
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 	}
 	client := &http.Client{Transport: tr}
 

--- a/src/internal/end2end/log_cache_test.go
+++ b/src/internal/end2end/log_cache_test.go
@@ -14,6 +14,7 @@ import (
 	"code.cloudfoundry.org/log-cache/internal/cache"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,20 +46,20 @@ var _ = Describe("LogCache", func() {
 			m,
 			logger,
 			cache.WithAddr(lc_addrs[0]),
-			cache.WithClustered(0, lc_addrs, grpc.WithInsecure()),
+			cache.WithClustered(0, lc_addrs, grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 
 		node2 = cache.New(
 			m,
 			logger,
 			cache.WithAddr(lc_addrs[1]),
-			cache.WithClustered(1, lc_addrs, grpc.WithInsecure()),
+			cache.WithClustered(1, lc_addrs, grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 
 		node1.Start()
 		node2.Start()
 
-		lc_client = client.NewClient(lc_addrs[0], client.WithViaGRPC(grpc.WithInsecure()))
+		lc_client = client.NewClient(lc_addrs[0], client.WithViaGRPC(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	})
 
 	AfterEach(func() {
@@ -122,7 +123,7 @@ var _ = Describe("LogCache", func() {
 })
 
 func ingressClient(addr string) (client rpc.IngressClient, cleanup func()) {
-	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
 	}

--- a/src/internal/gateway/gateway_test.go
+++ b/src/internal/gateway/gateway_test.go
@@ -12,6 +12,7 @@ import (
 	. "code.cloudfoundry.org/log-cache/internal/gateway"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"code.cloudfoundry.org/log-cache/internal/testing"
 	. "github.com/onsi/ginkgo"
@@ -29,7 +30,7 @@ func gatewayTestSetup() (*Gateway, *testing.SpyLogCache) {
 		WithGatewayVersion("1.2.3"),
 		WithGatewayVMUptimeFn(testing.StubUptimeFn),
 		WithGatewayLogCacheDialOpts(
-			grpc.WithInsecure(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		),
 	)
 	gw.Start()
@@ -96,6 +97,7 @@ var _ = Describe("Gateway", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		respBytes, err := ioutil.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(string(respBytes)).To(MatchRegexp(`\n$`))
 	})
 
@@ -219,6 +221,7 @@ func makeTLSReq(addr string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s", addr), nil)
 	Expect(err).ToNot(HaveOccurred())
 
+	//nolint:gosec
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}

--- a/src/internal/nozzle/nozzle.go
+++ b/src/internal/nozzle/nozzle.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type Metrics interface {
@@ -54,7 +55,7 @@ func NewNozzle(c StreamConnector, logCacheAddr string, m Metrics, logger *log.Lo
 	n := &Nozzle{
 		s:         c,
 		addr:      logCacheAddr,
-		opts:      []grpc.DialOption{grpc.WithInsecure()},
+		opts:      []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 		log:       logger,
 		metrics:   m,
 		selectors: []string{},

--- a/src/internal/nozzle/nozzle_test.go
+++ b/src/internal/nozzle/nozzle_test.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"code.cloudfoundry.org/log-cache/internal/testing"
 	. "github.com/onsi/ginkgo"
@@ -35,7 +36,7 @@ var _ = Describe("Nozzle", func() {
 			addr := logCache.Start()
 
 			n = NewNozzle(streamConnector, addr, spyMetrics, logger,
-				WithDialOpts(grpc.WithInsecure()),
+				WithDialOpts(grpc.WithTransportCredentials(insecure.NewCredentials())),
 				WithSelectors("gauge", "timer", "event"),
 				WithShardID("log-cache"),
 			)

--- a/src/internal/promql/promql.go
+++ b/src/internal/promql/promql.go
@@ -26,7 +26,6 @@ type PromQL struct {
 	failureCounter    metrics.Counter
 	instantQueryTimer metrics.Gauge
 	rangeQueryTimer   metrics.Gauge
-	failures          int
 
 	result int64
 
@@ -622,11 +621,14 @@ func ExtractSourceIds(query string) ([]string, error) {
 
 	visitor := newSourceIDVisitor()
 
-	promql.Walk(
+	err = promql.Walk(
 		visitor,
 		expr,
 		nil,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	var sourceIDs []string
 
@@ -690,11 +692,14 @@ func ReplaceSourceIdSets(query string, sourceIDExpansions map[string][]string) (
 
 	visitor := newSourceIdReplacementVisitor(sourceIDExpansions)
 
-	promql.Walk(
+	err = promql.Walk(
 		visitor,
 		expr,
 		nil,
 	)
+	if err != nil {
+		return "", err
+	}
 
 	return expr.String(), nil
 }

--- a/src/internal/promql/promql_test.go
+++ b/src/internal/promql/promql_test.go
@@ -1370,10 +1370,10 @@ func (s *spyDataReader) ReadEnvelopeTypes() [][]logcache_v1.EnvelopeType {
 	return result
 }
 
-func (s *spyDataReader) setRead(es [][]*loggregator_v2.Envelope, errs []error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// func (s *spyDataReader) setRead(es [][]*loggregator_v2.Envelope, errs []error) {
+// 	s.mu.Lock()
+// 	defer s.mu.Unlock()
 
-	s.readResults = es
-	s.readErrs = errs
-}
+// 	s.readResults = es
+// 	s.readErrs = errs
+// }

--- a/src/internal/promql/unimplemented_middleware.go
+++ b/src/internal/promql/unimplemented_middleware.go
@@ -9,6 +9,8 @@ func UnimplementedMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api/v1/query") {
 			w.WriteHeader(http.StatusNotImplemented)
+
+			//nolint:errcheck
 			w.Write([]byte(`{
 				"status": "error",
 				"errorType": "bad_data",

--- a/src/internal/routing/batched_ingress_client_test.go
+++ b/src/internal/routing/batched_ingress_client_test.go
@@ -74,13 +74,14 @@ var _ = Describe("BatchedIngressClient", func() {
 		}(ingressClient)
 
 		for i := 0; i < 25000; i++ {
-			c.Send(context.Background(), &rpc.SendRequest{
+			_, err := c.Send(context.Background(), &rpc.SendRequest{
 				Envelopes: &loggregator_v2.EnvelopeBatch{
 					Batch: []*loggregator_v2.Envelope{
 						{Timestamp: 1},
 					},
 				},
 			})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		Eventually(func() float64 {

--- a/src/internal/routing/egress_reverse_proxy.go
+++ b/src/internal/routing/egress_reverse_proxy.go
@@ -2,9 +2,10 @@ package routing
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"log"
-	"math/rand"
+	"math/big"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -70,7 +71,11 @@ func (e *EgressReverseProxy) Read(ctx context.Context, in *rpc.ReadRequest) (*rp
 }
 
 func (e *EgressReverseProxy) remoteRead(idx []int, ctx context.Context, in *rpc.ReadRequest) (*rpc.ReadResponse, error) {
-	response, err := e.clients[idx[rand.Intn(len(idx))]].Read(ctx, in)
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(len(idx))))
+	if err != nil {
+		return nil, err
+	}
+	response, err := e.clients[idx[int(nBig.Int64())]].Read(ctx, in)
 	if status.Code(err) == codes.Unavailable {
 		return &rpc.ReadResponse{
 			Envelopes: &loggregator_v2.EnvelopeBatch{

--- a/src/internal/routing/egress_reverse_proxy_test.go
+++ b/src/internal/routing/egress_reverse_proxy_test.go
@@ -300,10 +300,10 @@ var _ = Describe("EgressReverseProxy", func() {
 	It("uses the given context for meta", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		p.Meta(ctx, &rpc.MetaRequest{
+		_, err := p.Meta(ctx, &rpc.MetaRequest{
 			LocalOnly: true,
 		})
-
+		Expect(err).ToNot(HaveOccurred())
 		Expect(spyEgressLocalClient.ctxs[0].Done()).To(BeClosed())
 	})
 

--- a/src/internal/routing/local_store_reader.go
+++ b/src/internal/routing/local_store_reader.go
@@ -101,7 +101,7 @@ func (r *LocalStoreReader) Meta(ctx context.Context, req *logcache_v1.MetaReques
 	sourceIds := r.s.Meta()
 
 	metaInfo := make(map[string]*logcache_v1.MetaInfo)
-	for sourceId, _ := range sourceIds {
+	for sourceId := range sourceIds {
 		metaInfo[sourceId] = &logcache_v1.MetaInfo{
 			Count:           sourceIds[sourceId].Count,
 			Expired:         sourceIds[sourceId].Expired,

--- a/src/internal/syslog/server_test.go
+++ b/src/internal/syslog/server_test.go
@@ -483,7 +483,7 @@ var _ = Describe("Syslog", func() {
 				Expect(err).To(HaveOccurred())
 			}
 		},
-			Entry("unsupported SSL 3.0", tls.VersionSSL30, false),
+			Entry("unsupported SSL 3.0", tls.VersionSSL30, false), // nolint:staticcheck
 			Entry("unsupported TLS 1.0", tls.VersionTLS10, false),
 			Entry("unsupported TLS 1.1", tls.VersionTLS11, false),
 			Entry("supported TLS 1.2", tls.VersionTLS12, true),

--- a/src/internal/testing/tls_config.go
+++ b/src/internal/testing/tls_config.go
@@ -14,6 +14,7 @@ func NewTLSConfig(caPath, certPath, keyPath, cn string) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
 		ServerName:         cn,
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: false,

--- a/src/pkg/marshaler/marshaler_test.go
+++ b/src/pkg/marshaler/marshaler_test.go
@@ -762,7 +762,10 @@ func (m *mockMarshaler) Unmarshal(data []byte, v interface{}) error {
 
 func (m *mockMarshaler) NewEncoder(w io.Writer) runtime.Encoder {
 	return runtime.EncoderFunc(func(interface{}) error {
-		w.Write([]byte("mock encoded result"))
+		_, err := w.Write([]byte("mock encoded result"))
+		if err != nil {
+			return err
+		}
 
 		return m.encodeError
 	})


### PR DESCRIPTION
I've run golangci-lint and fixed all of the findings.

Remarks to these change:
- there are many functions which return error and are called in defer functions or run as goroutines. I've added a a comment to  ignored these findings
- there are many functions which are not used which I've commented out as I'm not sure if they should be kept or not
- There is a [RefreshTokenKeys](https://github.com/cloudfoundry/log-cache-release/blob/main/src/internal/auth/uaa_client.go#L88-L173) function in `uaa_client.go` which is called once as a [goroutine](https://github.com/cloudfoundry/log-cache-release/blob/main/src/internal/auth/uaa_client.go#L220) and once [directly](https://github.com/cloudfoundry/log-cache-release/blob/main/src/internal/auth/uaa_client.go#L255). Adding error check to the "normal" call makes few tests break as there are some timing issues. IMO it would we good if we refactor this in order to avoid problems. Do you thing this worth taking a look?

Fixes #97 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes
