### PR TITLE
Fix: flakey CAPI authorization test

### DIFF
--- a/src/internal/auth/capi_client_test.go
+++ b/src/internal/auth/capi_client_test.go
@@ -67,7 +67,7 @@ var _ = Describe("CAPIClient", func() {
 
 		It("sourceIDs from expired cached tokens are not authorized", func() {
 			tc := setup(
-				auth.WithCacheExpirationInterval(250 * time.Millisecond),
+				auth.WithCacheExpirationInterval(50 * time.Millisecond),
 			)
 
 			tc.capiClient.resps = []response{
@@ -79,17 +79,12 @@ var _ = Describe("CAPIClient", func() {
 				"token-0",
 			)).To(BeTrue())
 
-			time.Sleep(251 * time.Millisecond)
-
 			tc.capiClient.resps = []response{
 				newCapiResp(http.StatusNotFound), // app not found
 				newCapiResp(http.StatusNotFound), // fallthrough to see if it's a service
 			}
 
-			Expect(tc.client.IsAuthorized(
-				"8208c86c-7afe-45f8-8999-4883d5868cf2",
-				"token-0",
-			)).To(BeFalse())
+			Eventually(tc.client.IsAuthorized).WithArguments("8208c86c-7afe-45f8-8999-4883d5868cf2", "token-0").Should(BeFalse())
 		})
 
 		It("regularly removes tokens from cache", func() {


### PR DESCRIPTION
# Description

Stop depending upon a sleep to get past the point in time when a goroutine running on an interval has succesfully executed.

Also reduced the expiration interval, as there seemed no reason to keep it higher.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

cc @mkocher 
