### PR TITLE
Refactor pprof server setup

### DIFF
--- a/src/cmd/cf-auth-proxy/main.go
+++ b/src/cmd/cf-auth-proxy/main.go
@@ -1,19 +1,15 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net"
 	"net/http"
 
-	"code.cloudfoundry.org/tlsconfig"
-
-	//nolint:gosec
-	_ "net/http/pprof"
-
 	"net/url"
 	"os"
 	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	metrics "code.cloudfoundry.org/go-metric-registry"
 
@@ -24,6 +20,7 @@ import (
 	"code.cloudfoundry.org/log-cache/internal/auth"
 	. "code.cloudfoundry.org/log-cache/internal/cfauthproxy"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
+	"code.cloudfoundry.org/log-cache/internal/pprof"
 	"code.cloudfoundry.org/log-cache/internal/promql"
 )
 
@@ -67,12 +64,7 @@ func main() {
 	)
 	if cfg.MetricsServer.DebugMetrics {
 		metrics.RegisterDebugMetrics()
-		pprofServer := &http.Server{
-			Addr:              fmt.Sprintf("127.0.0.1:%d", cfg.MetricsServer.PprofPort),
-			Handler:           http.DefaultServeMux,
-			ReadHeaderTimeout: 2 * time.Second,
-		}
-		go func() { loggr.Println("PPROF SERVER STOPPED " + pprofServer.ListenAndServe().Error()) }()
+		go func() { loggr.Println("PPROF SERVER STOPPED " + pprof.RunServer(cfg.MetricsServer.PprofPort).Error()) }()
 	}
 
 	var options []auth.UAAOption

--- a/src/cmd/gateway/main.go
+++ b/src/cmd/gateway/main.go
@@ -1,21 +1,15 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"time"
 
 	metrics "code.cloudfoundry.org/go-metric-registry"
 	"code.cloudfoundry.org/tlsconfig"
 
-	"net/http"
-
-	//nolint: gosec
-	_ "net/http/pprof"
-
 	. "code.cloudfoundry.org/log-cache/internal/gateway"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
+	"code.cloudfoundry.org/log-cache/internal/pprof"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -59,12 +53,7 @@ func main() {
 	)
 	if cfg.MetricsServer.DebugMetrics {
 		m.RegisterDebugMetrics()
-		pprofServer := &http.Server{
-			Addr:              fmt.Sprintf("127.0.0.1:%d", cfg.MetricsServer.PprofPort),
-			Handler:           http.DefaultServeMux,
-			ReadHeaderTimeout: 2 * time.Second,
-		}
-		go func() { log.Println("PPROF SERVER STOPPED " + pprofServer.ListenAndServe().Error()) }()
+		go func() { log.Println("PPROF SERVER STOPPED " + pprof.RunServer(cfg.MetricsServer.PprofPort).Error()) }()
 	}
 
 	gatewayOptions := []GatewayOption{

--- a/src/cmd/log-cache/main.go
+++ b/src/cmd/log-cache/main.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"net/http"
-
-	//nolint:gosec
-	_ "net/http/pprof"
 
 	"os"
 	"os/signal"
@@ -19,6 +14,8 @@ import (
 	"code.cloudfoundry.org/go-envstruct"
 	. "code.cloudfoundry.org/log-cache/internal/cache"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
+	"code.cloudfoundry.org/log-cache/internal/pprof"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -66,12 +63,7 @@ func main() {
 	)
 	if cfg.MetricsServer.DebugMetrics {
 		m.RegisterDebugMetrics()
-		pprofServer := &http.Server{
-			Addr:              fmt.Sprintf("127.0.0.1:%d", cfg.MetricsServer.PprofPort),
-			Handler:           http.DefaultServeMux,
-			ReadHeaderTimeout: 2 * time.Second,
-		}
-		go func() { logger.Println("PPROF SERVER STOPPED " + pprofServer.ListenAndServe().Error()) }()
+		go func() { logger.Println("PPROF SERVER STOPPED " + pprof.RunServer(cfg.MetricsServer.PprofPort).Error()) }()
 	}
 
 	uptimeFn := m.NewGauge(

--- a/src/cmd/syslog-server/main.go
+++ b/src/cmd/syslog-server/main.go
@@ -1,20 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"net/http"
-
-	//nolint:gosec
-	_ "net/http/pprof"
-
 	"os"
-	"time"
 
 	"code.cloudfoundry.org/go-envstruct"
 	metrics "code.cloudfoundry.org/go-metric-registry"
 	. "code.cloudfoundry.org/log-cache/internal/nozzle"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
+	"code.cloudfoundry.org/log-cache/internal/pprof"
 	"code.cloudfoundry.org/log-cache/internal/syslog"
 	"code.cloudfoundry.org/tlsconfig"
 	"google.golang.org/grpc"
@@ -63,12 +57,7 @@ func main() {
 	)
 	if cfg.MetricsServer.DebugMetrics {
 		m.RegisterDebugMetrics()
-		pprofServer := &http.Server{
-			Addr:              fmt.Sprintf("127.0.0.1:%d", cfg.MetricsServer.PprofPort),
-			Handler:           http.DefaultServeMux,
-			ReadHeaderTimeout: 2 * time.Second,
-		}
-		go func() { loggr.Println("PPROF SERVER STOPPED " + pprofServer.ListenAndServe().Error()) }()
+		go func() { loggr.Println("PPROF SERVER STOPPED " + pprof.RunServer(cfg.MetricsServer.PprofPort).Error()) }()
 	}
 
 	serverOptions := []syslog.ServerOption{

--- a/src/internal/pprof/server.go
+++ b/src/internal/pprof/server.go
@@ -1,0 +1,25 @@
+package pprof
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"time"
+)
+
+func RunServer(port uint16) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second,
+	}
+
+	return srv.ListenAndServe()
+}


### PR DESCRIPTION
* Moves pprof server generation into a separate package so that the code is not duplicated across main functions.
* Updates pprof servers to use a non-default ServeMux, which decreases the risk of accidentally exposing pprof publicly in the future.