### PR TITLE
ci(dependabot): Watch for bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,41 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 0
 
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "v2.x"
-    schedule:
-      interval: "daily"
-    labels:
-    - "v2.x"
-    - "github_actions"
-    - "dependencies"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: "v2.x"
+  schedule:
+    interval: "weekly"
+  labels:
+  - "v2.x"
+  - "github_actions"
+  - "dependencies"
+  open-pull-requests-limit: 0
 
-  # Maintain dependencies for Go Modules
-  - package-ecosystem: "gomod"
-    directory: "/src"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/src"
-    target-branch: "v2.x"
-    schedule:
-      interval: "daily"
-    labels:
-    - "v2.x"
-    - "go"
-    - "dependencies"
+- package-ecosystem: "gomod"
+  directory: "/src"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "gomod"
+  directory: "/src"
+  target-branch: "v2.x"
+  schedule:
+    interval: ""weekly""
+  labels:
+  - "v2.x"
+  - "go"
+  - "dependencies"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "bundler"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 0

--- a/.github/workflows/template-specs.yml
+++ b/.github/workflows/template-specs.yml
@@ -1,0 +1,21 @@
+name: 'Template specs'
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+    - name: 'Run specs'
+      run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-group :test do
+ruby '3.2.2'
+
+group :development, :test do
   gem 'bosh-template'
   gem 'rspec'
   gem 'rspec-its'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bosh-template (2.2.1)
+    bosh-template (2.4.0)
       semi_semantic (~> 1.2.0)
-    diff-lcs (1.4.4)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    diff-lcs (1.5.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
+      rspec-support (~> 3.12.0)
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     semi_semantic (1.2.0)
 
 PLATFORMS
@@ -30,5 +30,8 @@ DEPENDENCIES
   rspec
   rspec-its
 
+RUBY VERSION
+   ruby 3.2.2p53
+
 BUNDLED WITH
-   1.17.2
+   2.4.10


### PR DESCRIPTION
- Configure dependabot to create pull requests to update the base Gemfile, which is used for release-level specs.
- Look for dependency updates weekly, but remove the open pull request limit. This should front-load our dependency bumps for the week for this repo, which I think will be preferable to constantly dealing with more bumps throughout the week. This doesn't affect security bumps.
