### PR TITLE
Bump to go1.21

### DIFF
--- a/packages/golang-1.20-linux/spec.lock
+++ b/packages/golang-1.20-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.20-linux
-fingerprint: 8859f2c2f47d9b58d85ae101405d8af92c7d26d30231721341bc49bd657ccb4d

--- a/packages/log-cache-cf-auth-proxy/packaging
+++ b/packages/log-cache-cf-auth-proxy/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-cf-auth-proxy ./cmd/cf-auth-proxy

--- a/packages/log-cache-cf-auth-proxy/spec
+++ b/packages/log-cache-cf-auth-proxy/spec
@@ -2,7 +2,7 @@
 name: log-cache-cf-auth-proxy
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - cmd/cf-auth-proxy/**/*.go

--- a/packages/log-cache-gateway/packaging
+++ b/packages/log-cache-gateway/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 VERSION=$(cat version)

--- a/packages/log-cache-gateway/spec
+++ b/packages/log-cache-gateway/spec
@@ -2,7 +2,7 @@
 name: log-cache-gateway
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - cmd/gateway/**/*.go

--- a/packages/log-cache-nozzle/packaging
+++ b/packages/log-cache-nozzle/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-nozzle ./cmd/nozzle

--- a/packages/log-cache-nozzle/spec
+++ b/packages/log-cache-nozzle/spec
@@ -2,7 +2,7 @@
 name: log-cache-nozzle
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - cmd/nozzle/**/*.go

--- a/packages/log-cache-syslog-server/packaging
+++ b/packages/log-cache-syslog-server/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-syslog-server ./cmd/syslog-server

--- a/packages/log-cache-syslog-server/spec
+++ b/packages/log-cache-syslog-server/spec
@@ -2,7 +2,7 @@
 name: log-cache-syslog-server
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - cmd/syslog-server/**/*.go

--- a/packages/log-cache/packaging
+++ b/packages/log-cache/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache ./cmd/log-cache

--- a/packages/log-cache/spec
+++ b/packages/log-cache/spec
@@ -2,7 +2,7 @@
 name: log-cache
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - cmd/log-cache/**/*.go

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/log-cache
 
-go 1.20
+go 1.21
 
 require (
 	code.cloudfoundry.org/go-batching v0.0.0-20220601181205-303abfc14b83

--- a/src/go.sum
+++ b/src/go.sum
@@ -281,6 +281,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -388,6 +389,7 @@ github.com/prometheus/prometheus v2.13.1+incompatible h1:2W7Aq4LQb71fD5QtFpATK3h
 github.com/prometheus/prometheus v2.13.1+incompatible/go.mod h1:SgN99nHQ/tVJyAuyLKKz6i2j5cJx3eLy9MCRCPOXqUI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -623,6 +625,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=


### PR DESCRIPTION
# Description

* Removes go1.20 packages
* Uses go1.21 packages to build the other packages
* Specify go1.21 as the go version in `src/go.mod`

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
