### PR TITLE
Increase open-pull-requests-limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 100
 
 - package-ecosystem: "github-actions"
   directory: "/"
@@ -15,13 +15,13 @@ updates:
   - "v2.x"
   - "github_actions"
   - "dependencies"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 100
 
 - package-ecosystem: "gomod"
   directory: "/src"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 100
 
 - package-ecosystem: "gomod"
   directory: "/src"
@@ -32,10 +32,10 @@ updates:
   - "v2.x"
   - "go"
   - "dependencies"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 100
 
 - package-ecosystem: "bundler"
   directory: "/"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 100


### PR DESCRIPTION
We had set open-pull-requests-limit to zero, but this has the effect of disabling dependabot updates:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
