### PR TITLE
Modernize packaging scripts

### DIFF
--- a/packages/log-cache-cf-auth-proxy/packaging
+++ b/packages/log-cache-cf-auth-proxy/packaging
@@ -1,6 +1,8 @@
-set -ex
+#!/bin/bash
 
+set -e -u -x -o pipefail
+
+# shellcheck source=/dev/null
 source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
-export GOPATH=/var/vcap
 
-go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-cf-auth-proxy ./cmd/cf-auth-proxy
+go build -o "${BOSH_INSTALL_TARGET}/log-cache-cf-auth-proxy" ./cmd/cf-auth-proxy

--- a/packages/log-cache-gateway/packaging
+++ b/packages/log-cache-gateway/packaging
@@ -1,10 +1,12 @@
-set -ex
+#!/bin/bash
 
+set -e -u -x -o pipefail
+
+# shellcheck source=/dev/null
 source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
-export GOPATH=/var/vcap
 
 VERSION=$(cat version)
-go build -mod=vendor \
-  -o ${BOSH_INSTALL_TARGET}/log-cache-gateway \
+go build \
+  -o "${BOSH_INSTALL_TARGET}/log-cache-gateway" \
   -ldflags "-X main.buildVersion=${VERSION}" \
   ./cmd/gateway

--- a/packages/log-cache-syslog-server/packaging
+++ b/packages/log-cache-syslog-server/packaging
@@ -1,6 +1,8 @@
-set -ex
+#!/bin/bash
 
+set -e -u -x -o pipefail
+
+# shellcheck source=/dev/null
 source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
-export GOPATH=/var/vcap
 
-go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-syslog-server ./cmd/syslog-server
+go build -o "${BOSH_INSTALL_TARGET}/log-cache-syslog-server" ./cmd/syslog-server

--- a/packages/log-cache/packaging
+++ b/packages/log-cache/packaging
@@ -1,6 +1,8 @@
-set -ex
+#!/bin/bash
 
+set -e -u -x -o pipefail
+
+# shellcheck source=/dev/null
 source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
-export GOPATH=/var/vcap
 
-go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache ./cmd/log-cache
+go build -o "${BOSH_INSTALL_TARGET}/log-cache" ./cmd/log-cache


### PR DESCRIPTION
# Description

- Adds shebang directive for the default shell (used when the directive is missing).
- Ignore shellcheck warnings related to missing `compile.env` source files.
- Removes unnecessary GOPATH export.
- Removes `-mod=vendor` flag from `go build` command, as that flag is on by default in recent versions of Go.

## Type of change

- [x] Maintenance chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes