### PR TITLE
Make whitespace trimming in log messages optional

### DIFF
--- a/jobs/log-cache-syslog-server/spec
+++ b/jobs/log-cache-syslog-server/spec
@@ -35,6 +35,9 @@ properties:
   syslog_idle_timeout:
     description: "Timeout for the Syslog Server connection"
     default: "2m"
+  syslog_trim_message_whitespace:
+    description: "Defines if the leading and trailing whitespace in the Syslog log messages should be trimmed"
+    default: true
 
   syslog_client_ca_cert:
     description: The CA certificate for key/cert verification.

--- a/jobs/log-cache-syslog-server/templates/bpm.yml.erb
+++ b/jobs/log-cache-syslog-server/templates/bpm.yml.erb
@@ -16,6 +16,7 @@ processes:
   env:
     SYSLOG_PORT: "<%= p('syslog_port') %>"
     SYSLOG_IDLE_TIMEOUT: "<%= p('syslog_idle_timeout') %>"
+    SYSLOG_TRIM_MESSAGE_WHITESPACE: "<%= p('syslog_trim_message_whitespace') %>"
 
     SYSLOG_TLS_CERT_PATH: "<%= "#{certDir}/syslog.crt" %>"
     SYSLOG_TLS_KEY_PATH: "<%= "#{certDir}/syslog.key" %>"

--- a/src/cmd/syslog-server/config.go
+++ b/src/cmd/syslog-server/config.go
@@ -18,8 +18,9 @@ type Config struct {
 	SyslogTLSCertPath string `env:"SYSLOG_TLS_CERT_PATH, report"`
 	SyslogTLSKeyPath  string `env:"SYSLOG_TLS_KEY_PATH, report"`
 
-	SyslogIdleTimeout      time.Duration `env:"SYSLOG_IDLE_TIMEOUT, report"`
-	SyslogMaxMessageLength int           `env:"SYSLOG_MAX_MESSAGE_LENGTH, report"`
+	SyslogIdleTimeout           time.Duration `env:"SYSLOG_IDLE_TIMEOUT, report"`
+	SyslogMaxMessageLength      int           `env:"SYSLOG_MAX_MESSAGE_LENGTH, report"`
+	SyslogTrimMessageWhitespace bool          `env:"SYSLOG_TRIM_MESSAGE_WHITESPACE, report"`
 
 	SyslogClientTrustedCAFile string `env:"SYSLOG_CLIENT_TRUSTED_CA_FILE,  report"`
 
@@ -36,7 +37,8 @@ func LoadConfig() (*Config, error) {
 		MetricsServer: config.MetricsServer{
 			Port: 6061,
 		},
-		SyslogMaxMessageLength: 65 * 1024, // Diego should never send logs bigger than 64Kib
+		SyslogMaxMessageLength:      65 * 1024, // Diego should never send logs bigger than 64Kib
+		SyslogTrimMessageWhitespace: true,
 	}
 
 	if err := envstruct.Load(&c); err != nil {

--- a/src/cmd/syslog-server/main.go
+++ b/src/cmd/syslog-server/main.go
@@ -75,6 +75,7 @@ func main() {
 		syslog.WithServerPort(cfg.SyslogPort),
 		syslog.WithIdleTimeout(cfg.SyslogIdleTimeout),
 		syslog.WithServerMaxMessageLength(cfg.SyslogMaxMessageLength),
+		syslog.WithServerTrimMessageWhitespace(cfg.SyslogTrimMessageWhitespace),
 	}
 	if cfg.SyslogTLSCertPath != "" || cfg.SyslogTLSKeyPath != "" {
 		serverOptions = append(serverOptions, syslog.WithServerTLS(cfg.SyslogTLSCertPath, cfg.SyslogTLSKeyPath))


### PR DESCRIPTION
# Description
The Log Cache Syslog server trims leading and trailing whitespace in the messages. The log messages should be not changed.

This change:
- adds config parameter to define if the whitespace in the log messages should be trimmed or not
- trims or leaves the log message untouched based on the config parameter

The default behavior is to trim the log messages, so that it is compatible with the behavior up until now.

Fixes #505 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

