### PR TITLE
chore: Increase test timeout in internal/syslog

### DIFF
--- a/src/internal/syslog/server_test.go
+++ b/src/internal/syslog/server_test.go
@@ -618,7 +618,7 @@ func buildSyslogWithTags(structuredData, tags string) string {
 }
 
 func waitForServerToStart(server *syslog.Server) {
-	Eventually(server.Addr, "1s", "100ms").ShouldNot(BeEmpty())
+	Eventually(server.Addr, "5s", "100ms").ShouldNot(BeEmpty())
 }
 
 const counterDataFormat = `counter@47450 name="%s" total="%s" delta="%s"`


### PR DESCRIPTION
# Description

Increases the timeout for the server in internal/syslog to come up to help give tests on machines under load more time to complete.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
