### PR TITLE
Bump to Go1.22

### DIFF
--- a/packages/golang-1.21-linux/spec.lock
+++ b/packages/golang-1.21-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.21-linux
-fingerprint: 55147e471cfe150f63898ed1ae13b6cb48dac8f198d415319b14572ea7a55443

--- a/packages/log-cache-cf-auth-proxy/packaging
+++ b/packages/log-cache-cf-auth-proxy/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-cf-auth-proxy ./cmd/cf-auth-proxy

--- a/packages/log-cache-cf-auth-proxy/spec
+++ b/packages/log-cache-cf-auth-proxy/spec
@@ -2,7 +2,7 @@
 name: log-cache-cf-auth-proxy
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/cf-auth-proxy/**/*.go

--- a/packages/log-cache-gateway/packaging
+++ b/packages/log-cache-gateway/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 VERSION=$(cat version)

--- a/packages/log-cache-gateway/spec
+++ b/packages/log-cache-gateway/spec
@@ -2,7 +2,7 @@
 name: log-cache-gateway
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/gateway/**/*.go

--- a/packages/log-cache-nozzle/packaging
+++ b/packages/log-cache-nozzle/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-nozzle ./cmd/nozzle

--- a/packages/log-cache-nozzle/spec
+++ b/packages/log-cache-nozzle/spec
@@ -2,7 +2,7 @@
 name: log-cache-nozzle
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/nozzle/**/*.go

--- a/packages/log-cache-syslog-server/packaging
+++ b/packages/log-cache-syslog-server/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache-syslog-server ./cmd/syslog-server

--- a/packages/log-cache-syslog-server/spec
+++ b/packages/log-cache-syslog-server/spec
@@ -2,7 +2,7 @@
 name: log-cache-syslog-server
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/syslog-server/**/*.go

--- a/packages/log-cache/packaging
+++ b/packages/log-cache/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/log-cache ./cmd/log-cache

--- a/packages/log-cache/spec
+++ b/packages/log-cache/spec
@@ -2,7 +2,7 @@
 name: log-cache
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/log-cache/**/*.go

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,6 @@
 module code.cloudfoundry.org/log-cache
 
-go 1.21.0
-
-toolchain go1.21.12
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/go-batching v0.0.0-20240604201829-c8533406dd64


### PR DESCRIPTION
# Description

- Removes go1.21 packages
- Uses go1.22 packages to build the other packages
- Specify go1.22 as the go version in src/go.mod

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
