### PR TITLE
Update README to include descending parameter for /api/v1/read/ endpoint

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -85,9 +85,11 @@ Query Parameters:
   to include more types.
 - **limit** is the maximum number of envelopes to request. The max limit size
   is 1000 and defaults to 100.
+- **descending** is a parameter for sorting in descending order. If the
+  parameter is not provided the results will be sort in ascending order by default.  
 
 ```shell
-$ curl "https://<log-cache-addr>/api/v1/read/<source-id>?start_time=<start-time>&end_time=<end-time>"
+$ curl "https://<log-cache-addr>/api/v1/read/<source-id>?start_time=<start-time>&end_time=<end-time>&descending=true"
 ```
 
 ##### Response Body


### PR DESCRIPTION
# Description
 
I recently raised an issue https://github.com/cloudfoundry/log-cache-release/issues/544 asking the [README.md](https://github.com/cloudfoundry/log-cache-release/blob/main/src/README.md) file be updated to include the `descending` parameter for the `/api/v1/read/` endpoint. In response, @chombium suggested that I could add the parameter myself if I wanted to. So, I have created this pull request to make the necessary changes.

## Type of change
Documentation update


Fixes #544 

