### PR TITLE
ci: Disable parallel unit tests in CI

### DIFF
--- a/scripts/subtests/unit-test
+++ b/scripts/subtests/unit-test
@@ -5,7 +5,12 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+flags='-r --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace'
+if [ "${CI:-false}" = 'false' ]; then
+    flags="${flags} -p"
+fi
+
 pushd "${SCRIPT_DIR}/../../src" > /dev/null
-    go run github.com/onsi/ginkgo/v2/ginkgo -r -p --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace
+    go run github.com/onsi/ginkgo/v2/ginkgo $flags
 popd > /dev/null
 


### PR DESCRIPTION
# Description
Port of recent update in other logging repos: allow CI to disable parallel tests to avoid flakes in resource constrained envs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes
