### PR TITLE
fix: use Succeed() instead of BeNil()

### DIFF
--- a/src/internal/cache/log_cache_test.go
+++ b/src/internal/cache/log_cache_test.go
@@ -202,7 +202,7 @@ var _ = Describe("LogCache", func() {
 			es = resp.Envelopes.Batch
 			return nil
 		}
-		Eventually(f).Should(BeNil())
+		Eventually(f).Should(Succeed())
 
 		Expect(es[0].Timestamp).To(Equal(int64(4)))
 		Expect(es[0].SourceId).To(Equal("src-zero"))
@@ -258,7 +258,7 @@ var _ = Describe("LogCache", func() {
 
 			return nil
 		}
-		Eventually(f).Should(BeNil())
+		Eventually(f).Should(Succeed())
 	})
 
 	It("queries data via PromQL Range Queries", func() {
@@ -302,7 +302,7 @@ var _ = Describe("LogCache", func() {
 
 			return nil
 		}
-		Eventually(f).Should(BeNil())
+		Eventually(f).Should(Succeed())
 	})
 
 	It("routes envelopes to peers", func() {
@@ -370,7 +370,7 @@ var _ = Describe("LogCache", func() {
 			es = resp.Envelopes.Batch
 			return nil
 		}
-		Eventually(f).Should(BeNil())
+		Eventually(f).Should(Succeed())
 
 		Expect(es[0].Timestamp).To(Equal(int64(1)))
 		Expect(es[0].SourceId).To(Equal("src-zero"))


### PR DESCRIPTION
# Description
Fix linter issue with use of BeNil() matcher for a function that returns error. Use Succeed() matcher instead. Only showed up now because of recent linter change to correctly check for the issue in async assertions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Testing performed?
- [x] Unit tests

## Checklist:
- [x] This PR is being made against the `main` branch, or relevant version branch
