### PR TITLE
Using xxhash v2

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -12,7 +12,7 @@ require (
 	code.cloudfoundry.org/tlsconfig v0.10.0
 	github.com/Benjamintf1/unmarshalledmatchers v0.0.0-20190408201839-bb1c1f34eaea
 	github.com/benbjohnson/jmphash v0.0.0-20141216154655-2d58f234cd86
-	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cloudfoundry/gosigar v1.3.77
 	github.com/dvsekhvalnov/jose2go v1.8.0
 	github.com/emirpasic/gods v1.18.1
@@ -32,6 +32,7 @@ require (
 require (
 	code.cloudfoundry.org/go-log-cache/v3 v3.0.3
 	code.cloudfoundry.org/go-loggregator/v10 v10.0.1
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/shirou/gopsutil/v4 v4.24.10
 )
@@ -43,7 +44,6 @@ require (
 	github.com/benjamintf1/unmarshalledmatchers v0.0.0-20190408201839-bb1c1f34eaea // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/ebitengine/purego v0.8.1 // indirect
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/go-kit/kit v0.13.0 // indirect

--- a/src/internal/routing/routing_table.go
+++ b/src/internal/routing/routing_table.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/benbjohnson/jmphash"
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 )
 
 // RoutingTable makes decisions for where a item should be routed.

--- a/src/vendor/github.com/prometheus/prometheus/pkg/labels/labels.go
+++ b/src/vendor/github.com/prometheus/prometheus/pkg/labels/labels.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 )
 
 const sep = '\xff'

--- a/src/vendor/github.com/prometheus/prometheus/tsdb/labels/labels.go
+++ b/src/vendor/github.com/prometheus/prometheus/tsdb/labels/labels.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
# Description

The log-cache-version currently uses the xxhash dependency of version 1.1.0.
This PR updates the xxhash dependency in the log-cache-version to [2.3.0](https://github.com/cespare/xxhash/releases/tag/v2.3.0).
Update xxhash from 
`github.com/cespare/xxhash v1.1.0`
to 
`github.com/cespare/xxhash/v2 v2.3.0`.

All imports have been checked and adjusted.
Unit tests have run successfully.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
