### PR TITLE
CAPI call migration from  v2 to v3

### DIFF
--- a/src/internal/auth/capi_client.go
+++ b/src/internal/auth/capi_client.go
@@ -111,7 +111,7 @@ func (c *CAPIClient) HasApp(sourceID, authToken string) bool {
 }
 
 func (c *CAPIClient) HasService(sourceID, authToken string) bool {
-	req, err := http.NewRequest(http.MethodGet, c.addr+"/v2/service_instances/"+sourceID, nil)
+	req, err := http.NewRequest(http.MethodGet, c.addr+"/v3/service_instances/"+sourceID, nil)
 	if err != nil {
 		c.log.Printf("failed to build authorize log access request: %s", err)
 		return false

--- a/src/internal/auth/capi_client_test.go
+++ b/src/internal/auth/capi_client_test.go
@@ -147,7 +147,7 @@ var _ = Describe("CAPIClient", func() {
 			Expect(tc.capiClient.requests).To(HaveLen(1))
 			serviceReq := tc.capiClient.requests[0]
 			Expect(serviceReq.Method).To(Equal(http.MethodGet))
-			Expect(serviceReq.URL.String()).To(Equal("http://internal.capi.com/v2/service_instances/some-source"))
+			Expect(serviceReq.URL.String()).To(Equal("http://internal.capi.com/v3/service_instances/some-source"))
 			Expect(serviceReq.Header.Get("Authorization")).To(Equal("some-token"))
 		})
 
@@ -162,7 +162,7 @@ var _ = Describe("CAPIClient", func() {
 			Expect(tc.capiClient.requests).To(HaveLen(1))
 			serviceReq := tc.capiClient.requests[0]
 			Expect(serviceReq.Method).To(Equal(http.MethodGet))
-			Expect(serviceReq.URL.String()).To(Equal("http://internal.capi.com/v2/service_instances/some-source"))
+			Expect(serviceReq.URL.String()).To(Equal("http://internal.capi.com/v3/service_instances/some-source"))
 			Expect(serviceReq.Header.Get("Authorization")).To(Equal("some-token"))
 		})
 


### PR DESCRIPTION
# Description

The CAPI v2 is deprecated and will be deactivated in the cf-deployment. Therefore an update is needed to use the newer CAPI v3.

I've tested by using the Log Cache CF CLI plugin to access the Log Cache API with an admin and non admin user and everything went well. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes


