### PR TITLE
Move to golangci v2

### DIFF
--- a/scripts/subtests/lint
+++ b/scripts/subtests/lint
@@ -9,7 +9,7 @@ set +e
 golangci_lint_executable=$(which golangci-lint)
 set -e
 if [ -z "${golangci_lint_executable}" ] || [ ! -x "${golangci_lint_executable}" ]; then
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 fi
 
 pushd "${SCRIPT_DIR}/../../src" > /dev/null

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,6 +1,8 @@
+version: "2"
+
 run:
-  # Timeout for analysis.
-  # Default: 1m.
+  # Timeout full work, e.g. 30s, 5m.
+  # Default: none
   timeout: 5m
 
 linters:
@@ -13,9 +15,28 @@ linters:
     - gosec
     # Enforces standards of using ginkgo and gomega.
     - ginkgolinter
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   # Disable max issues per linter.
   max-issues-per-linter: 0
   # Disable max same issues.
   max-same-issues: 0
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/src/cmd/gateway/main.go
+++ b/src/cmd/gateway/main.go
@@ -14,7 +14,7 @@ import (
 	//nolint: gosec
 	_ "net/http/pprof"
 
-	. "code.cloudfoundry.org/log-cache/internal/gateway"
+	"code.cloudfoundry.org/log-cache/internal/gateway"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -67,14 +67,14 @@ func main() {
 		go func() { log.Println("PPROF SERVER STOPPED " + pprofServer.ListenAndServe().Error()) }()
 	}
 
-	gatewayOptions := []GatewayOption{
-		WithGatewayLogger(gatewayLoggr),
-		WithGatewayVersion(cfg.Version),
-		WithGatewayBlock(),
+	gatewayOptions := []gateway.GatewayOption{
+		gateway.WithGatewayLogger(gatewayLoggr),
+		gateway.WithGatewayVersion(cfg.Version),
+		gateway.WithGatewayBlock(),
 	}
 
 	if cfg.ProxyCertPath != "" || cfg.ProxyKeyPath != "" {
-		gatewayOptions = append(gatewayOptions, WithGatewayTLSServer(cfg.ProxyCertPath, cfg.ProxyKeyPath))
+		gatewayOptions = append(gatewayOptions, gateway.WithGatewayTLSServer(cfg.ProxyCertPath, cfg.ProxyKeyPath))
 	}
 	if cfg.TLS.HasAnyCredential() {
 		tlsConfig, err := tlsconfig.Build(
@@ -88,13 +88,13 @@ func main() {
 			panic(err)
 		}
 
-		gatewayOptions = append(gatewayOptions, WithGatewayLogCacheDialOpts(
+		gatewayOptions = append(gatewayOptions, gateway.WithGatewayLogCacheDialOpts(
 			grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50*1024*1024)),
 		),
 		)
 	} else {
-		gatewayOptions = append(gatewayOptions, WithGatewayLogCacheDialOpts(
+		gatewayOptions = append(gatewayOptions, gateway.WithGatewayLogCacheDialOpts(
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50*1024*1024)),
 		),
@@ -102,7 +102,7 @@ func main() {
 
 	}
 
-	gateway := NewGateway(cfg.LogCacheAddr, cfg.Addr, gatewayOptions...)
+	gw := gateway.NewGateway(cfg.LogCacheAddr, cfg.Addr, gatewayOptions...)
 
-	gateway.Start()
+	gw.Start()
 }

--- a/src/cmd/log-cache/main.go
+++ b/src/cmd/log-cache/main.go
@@ -17,7 +17,7 @@ import (
 	"code.cloudfoundry.org/tlsconfig"
 
 	"code.cloudfoundry.org/go-envstruct"
-	. "code.cloudfoundry.org/log-cache/internal/cache"
+	"code.cloudfoundry.org/log-cache/internal/cache"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -89,17 +89,17 @@ func main() {
 		}
 	}(time.Now())
 
-	logCacheOptions := []LogCacheOption{
-		WithAddr(cfg.Addr),
-		WithMemoryLimitPercent(float64(cfg.MemoryLimitPercent)),
-		WithMemoryLimit(cfg.MemoryLimit),
-		WithMaxPerSource(cfg.MaxPerSource),
-		WithQueryTimeout(cfg.QueryTimeout),
-		WithTruncationInterval(cfg.TruncationInterval),
-		WithPrunesPerGC(cfg.PrunesPerGC),
-		WithIngressBufferSize(cfg.IngressBufferSize),
-		WithIngressBufferReadBatchSize(cfg.IngressBufferReadBatchSize),
-		WithIngressBufferReadBatchInterval(cfg.IngressBufferReadBatchInterval),
+	logCacheOptions := []cache.LogCacheOption{
+		cache.WithAddr(cfg.Addr),
+		cache.WithMemoryLimitPercent(float64(cfg.MemoryLimitPercent)),
+		cache.WithMemoryLimit(cfg.MemoryLimit),
+		cache.WithMaxPerSource(cfg.MaxPerSource),
+		cache.WithQueryTimeout(cfg.QueryTimeout),
+		cache.WithTruncationInterval(cfg.TruncationInterval),
+		cache.WithPrunesPerGC(cfg.PrunesPerGC),
+		cache.WithIngressBufferSize(cfg.IngressBufferSize),
+		cache.WithIngressBufferReadBatchSize(cfg.IngressBufferReadBatchSize),
+		cache.WithIngressBufferReadBatchInterval(cfg.IngressBufferReadBatchInterval),
 	}
 	var transport grpc.DialOption
 	if cfg.TLS.HasAnyCredential() {
@@ -125,24 +125,24 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		logCacheOptions = append(logCacheOptions, WithServerOpts(grpc.Creds(credentials.NewTLS(tlsConfigServer)), grpc.MaxRecvMsgSize(50*1024*1024)))
+		logCacheOptions = append(logCacheOptions, cache.WithServerOpts(grpc.Creds(credentials.NewTLS(tlsConfigServer)), grpc.MaxRecvMsgSize(50*1024*1024)))
 	} else {
 		transport = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
-	logCacheOptions = append(logCacheOptions, WithClustered(
+	logCacheOptions = append(logCacheOptions, cache.WithClustered(
 		cfg.NodeIndex,
 		cfg.NodeAddrs,
 		transport,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50*1024*1024)),
 	))
 
-	cache := New(
+	lc := cache.New(
 		m,
 		logger,
 		logCacheOptions...,
 	)
 
-	cache.Start()
+	lc.Start()
 	waitForTermination()
 }
 

--- a/src/cmd/syslog-server/main.go
+++ b/src/cmd/syslog-server/main.go
@@ -13,7 +13,7 @@ import (
 
 	"code.cloudfoundry.org/go-envstruct"
 	metrics "code.cloudfoundry.org/go-metric-registry"
-	. "code.cloudfoundry.org/log-cache/internal/nozzle"
+	"code.cloudfoundry.org/log-cache/internal/nozzle"
 	"code.cloudfoundry.org/log-cache/internal/plumbing"
 	"code.cloudfoundry.org/log-cache/internal/syslog"
 	"code.cloudfoundry.org/tlsconfig"
@@ -96,7 +96,7 @@ func main() {
 
 	go server.Start()
 
-	nozzleOptions := []NozzleOption{}
+	nozzleOptions := []nozzle.NozzleOption{}
 	if cfg.LogCacheTLS.HasAnyCredential() {
 		tlsConfig, err := tlsconfig.Build(
 			tlsconfig.WithInternalServiceDefaults(),
@@ -108,12 +108,12 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		nozzleOptions = append(nozzleOptions, WithDialOpts(grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))))
+		nozzleOptions = append(nozzleOptions, nozzle.WithDialOpts(grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))))
 	} else {
-		nozzleOptions = append(nozzleOptions, WithDialOpts(grpc.WithTransportCredentials(insecure.NewCredentials())))
+		nozzleOptions = append(nozzleOptions, nozzle.WithDialOpts(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 
-	nozzle := NewNozzle(
+	noz := nozzle.NewNozzle(
 		server,
 		cfg.LogCacheAddr,
 		m,
@@ -121,5 +121,5 @@ func main() {
 		nozzleOptions...,
 	)
 
-	nozzle.Start()
+	noz.Start()
 }

--- a/src/internal/gateway/gateway.go
+++ b/src/internal/gateway/gateway.go
@@ -179,7 +179,7 @@ func (g *Gateway) listenAndServe() {
 }
 
 func (g *Gateway) handleInfoEndpoint(w http.ResponseWriter, r *http.Request) {
-	_, err := w.Write([]byte(fmt.Sprintf(`{"version":"%s","vm_uptime":"%d"}`+"\n", g.logCacheVersion, g.uptimeFn())))
+	_, err := fmt.Fprintf(w, `{"version":"%s","vm_uptime":"%d"}`+"\n", g.logCacheVersion, g.uptimeFn())
 	if err != nil {
 		g.log.Println("Cannot send result for the info endpoint")
 	}

--- a/src/internal/promql/promql.go
+++ b/src/internal/promql/promql.go
@@ -340,7 +340,7 @@ func (l *LogCacheQuerier) Select(params *storage.SelectParams, ll ...*labels.Mat
 	}
 
 	if len(sourceIDs) == 0 {
-		err := fmt.Errorf("Metric '%s' does not have a 'source_id' label.", metric)
+		err := fmt.Errorf("metric '%s' does not have a 'source_id' label", metric)
 		l.errf(err)
 		return nil, nil, err
 	}

--- a/src/internal/routing/local_store_reader.go
+++ b/src/internal/routing/local_store_reader.go
@@ -49,11 +49,11 @@ func (r *LocalStoreReader) Read(ctx context.Context, req *logcache_v1.ReadReques
 	}
 
 	if req.Limit > 1000 {
-		return nil, fmt.Errorf("Limit (%d) must be 1000 or less", req.Limit)
+		return nil, fmt.Errorf("limit (%d) must be 1000 or less", req.Limit)
 	}
 
 	if req.Limit < 0 {
-		return nil, fmt.Errorf("Limit (%d) must be greater than zero", req.Limit)
+		return nil, fmt.Errorf("limit (%d) must be greater than zero", req.Limit)
 	}
 
 	if req.EndTime == 0 {
@@ -69,7 +69,7 @@ func (r *LocalStoreReader) Read(ctx context.Context, req *logcache_v1.ReadReques
 	if req.NameFilter != "" {
 		nameFilter, err = regexp.Compile(req.NameFilter)
 		if err != nil {
-			return nil, fmt.Errorf("Name filter must be a valid regular expression: %s", err)
+			return nil, fmt.Errorf("name filter must be a valid regular expression: %s", err)
 		}
 	}
 

--- a/src/internal/routing/routing_table.go
+++ b/src/internal/routing/routing_table.go
@@ -47,7 +47,7 @@ func (t *RoutingTable) Lookup(item string) []int {
 	node := t.hasher.Hash(hashValue)
 
 	var result []int
-	var replicationFactor int = int(t.replicationFactor) //#nosec G115
+	var replicationFactor = int(t.replicationFactor) //#nosec G115
 	for n := 0; n < replicationFactor; n++ {
 		result = append(result, (node+n*replicationFactor)%len(t.addresses))
 	}

--- a/src/internal/testing/acceptance.go
+++ b/src/internal/testing/acceptance.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"net"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:staticcheck
 )
 
 func GetFreePort() int {

--- a/src/internal/testing/auth.go
+++ b/src/internal/testing/auth.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:staticcheck
 )
 
 func NewServerRequest(method, uri string, body io.Reader) (*http.Request, error) {

--- a/src/internal/testing/time.go
+++ b/src/internal/testing/time.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:staticcheck
 )
 
 func FormatTimeWithDecimalMillis(t time.Time) string {


### PR DESCRIPTION
# Description

Move to golangci-lint v2.

Issues were:

* [ST1001](https://staticcheck.dev/docs/checks/#ST1001): Do not use dot imports for sources under `cmd`.
* [ST1005](https://staticcheck.dev/docs/checks/#ST1005): to have nicer logs
* [QF1011](https://staticcheck.dev/docs/checks/#QF1011): Remove redundant type `int`
* [QF1012](https://staticcheck.dev/docs/checks/#QF1012): Use `fmt.Fprintf(x, ...)` instead of `x.Write(fmt.Sprintf(...))`

Noteworthy changes in golangci-lint v2:

* New config format (migrated with `migrate` command)
* Default timeout is now 0 instead of 1 minute. See [here](https://github.com/golangci/golangci-lint/pull/5470/commits/d3bf353d4531c824201394821f0119a690a01519#r1968522617) for rationale. Kept ours unchanged for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
